### PR TITLE
feat: add CLI and MCP server targets for headless/AI integration

### DIFF
--- a/Apple Notes Exporter/Apple Notes Exporter CLI/AppleNotesExporterCLI.entitlements
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/AppleNotesExporterCLI.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<false/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<false/>
+	<key>com.apple.security.cs.debugger</key>
+	<false/>
+</dict>
+</plist>

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/CLIError.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/CLIError.swift
@@ -1,0 +1,71 @@
+//
+//  CLIError.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+// MARK: - CLI Errors
+
+enum CLIError: Error {
+    case databaseUnavailable
+    case noNotesFound
+    case invalidOutputDirectory(String)
+    case unsupportedFormat(ExportFormat)
+    case repositoryError(String)
+    case fileSystemError(String)
+
+    var exitCode: Int32 {
+        switch self {
+        case .databaseUnavailable:    return 2
+        case .noNotesFound:           return 0   // not an error — empty result
+        case .invalidOutputDirectory: return 2
+        case .unsupportedFormat:      return 2
+        case .repositoryError:        return 2
+        case .fileSystemError:        return 1
+        }
+    }
+
+    var errorCode: String {
+        switch self {
+        case .databaseUnavailable:       return "databaseUnavailable"
+        case .noNotesFound:              return "noNotesFound"
+        case .invalidOutputDirectory:    return "invalidOutputDirectory"
+        case .unsupportedFormat:         return "unsupportedFormat"
+        case .repositoryError:           return "repositoryError"
+        case .fileSystemError:           return "fileSystemError"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .databaseUnavailable:
+            return "Cannot read the Notes database. Grant Full Disk Access to Terminal in System Settings → Privacy & Security → Full Disk Access."
+        case .noNotesFound:
+            return "No notes found matching the specified criteria."
+        case .invalidOutputDirectory(let path):
+            return "Invalid or inaccessible output directory: \(path)"
+        case .unsupportedFormat(let format):
+            return "Format '\(format.rawValue)' is not supported in the CLI. Supported formats: html, markdown, rtf, txt, tex. For PDF, export as HTML and convert using a PDF printer or pandoc."
+        case .repositoryError(let detail):
+            return "Repository error: \(detail)"
+        case .fileSystemError(let detail):
+            return "File system error: \(detail)"
+        }
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/CLIExportEngine.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/CLIExportEngine.swift
@@ -1,0 +1,691 @@
+//
+//  CLIExportEngine.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import OSLog
+
+// MARK: - CLI Export Engine
+
+/// Headless export actor — contains all export logic extracted from ExportViewModel
+/// with @MainActor / @Published machinery removed. Designed to be transport-agnostic
+/// so a future MCP target can call it directly without subprocess overhead.
+actor CLIExportEngine {
+
+    // MARK: - Types
+
+    struct ExportResult: Encodable {
+        let success: Bool
+        let exported: Int
+        let skipped: Int
+        let failed: Int
+        let failedAttachments: Int
+        let outputDirectory: String
+        let format: String
+        let durationSeconds: Double
+    }
+
+    // MARK: - Properties
+
+    private let repository: NotesRepository
+    let configurations: ExportConfigurations
+    private let databasePath: String
+
+    private var maxConcurrentExports: Int {
+        let coreCount = ProcessInfo.processInfo.processorCount
+        let totalMemory = ProcessInfo.processInfo.physicalMemory
+        let totalMemoryGB = Int(ceil(Double(totalMemory) / 1_073_741_824.0))
+        let memoryLimit = max(1, totalMemoryGB / 2)
+        return max(1, min(min(coreCount, memoryLimit), 16))
+    }
+
+    // MARK: - Init
+
+    init(
+        databasePath: String = "\(NSHomeDirectory())/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite",
+        configurations: ExportConfigurations = .default
+    ) {
+        self.databasePath = databasePath
+        self.configurations = configurations
+        self.repository = DatabaseNotesRepository(databasePath: databasePath)
+    }
+
+    // MARK: - Public API
+
+    /// Export the given notes to outputURL in the specified format.
+    func exportNotes(
+        _ notes: [NotesNote],
+        toDirectory outputURL: URL,
+        format: ExportFormat,
+        includeAttachments: Bool,
+        verbose: Bool,
+        progressHandler: @Sendable @escaping (Int, Int) -> Void
+    ) async throws -> ExportResult {
+        guard format != .pdf else {
+            throw CLIError.unsupportedFormat(format)
+        }
+
+        let startTime = Date()
+
+        // Incremental sync
+        let isSync = configurations.incrementalSync
+        let existingManifest = isSync ? SyncManifest.load(from: outputURL) : nil
+        let syncTracker: SyncManifestTracker?
+
+        let notesToExport: [NotesNote]
+        if isSync, let manifest = existingManifest {
+            notesToExport = manifest.notesNeedingExport(from: notes)
+            syncTracker = SyncManifestTracker(manifest: manifest)
+            if notesToExport.isEmpty {
+                if verbose { CLIOutput.writeStderr("All notes are up to date, nothing to export.") }
+                var updatedManifest = manifest
+                updatedManifest.lastSync = Date()
+                try updatedManifest.save(to: outputURL)
+                return ExportResult(
+                    success: true, exported: 0, skipped: notes.count, failed: 0, failedAttachments: 0,
+                    outputDirectory: outputURL.path, format: format.fileExtension,
+                    durationSeconds: Date().timeIntervalSince(startTime)
+                )
+            }
+            if verbose { CLIOutput.writeStderr("Incremental sync: \(notesToExport.count) new/changed of \(notes.count) total") }
+        } else {
+            notesToExport = notes
+            syncTracker = isSync ? SyncManifestTracker(manifest: .empty()) : nil
+        }
+
+        // Build account/folder hierarchy for output directory structure
+        let hierarchy = try await organizeNotesByHierarchy(notesToExport)
+
+        // Create directory structure
+        for (accountName, folders) in hierarchy {
+            let accountURL = outputURL.appendingPathComponent(sanitizeFilename(accountName))
+            try FileManager.default.createDirectory(at: accountURL, withIntermediateDirectories: true)
+            for (folderPath, _) in folders {
+                let folderURL = accountURL.appendingPathComponent(folderPath)
+                try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            }
+        }
+
+        // Flatten for concurrent export
+        var notesWithPaths: [(note: NotesNote, folderURL: URL)] = []
+        for (accountName, folders) in hierarchy {
+            let accountURL = outputURL.appendingPathComponent(sanitizeFilename(accountName))
+            for (folderPath, folderNotes) in folders {
+                let folderURL = accountURL.appendingPathComponent(folderPath)
+                for note in folderNotes {
+                    notesWithPaths.append((note: note, folderURL: folderURL))
+                }
+            }
+        }
+
+        let tracker = ExportProgressTracker()
+
+        if configurations.concatenateOutput {
+            try await exportNotesConcatenated(
+                notesWithPaths, format: format,
+                includeAttachments: includeAttachments,
+                outputURL: outputURL, verbose: verbose, tracker: tracker,
+                progressHandler: progressHandler
+            )
+        } else {
+            try await exportNotesConcurrently(
+                notesWithPaths, format: format,
+                includeAttachments: includeAttachments,
+                totalNotes: notesToExport.count, startTime: startTime,
+                syncTracker: syncTracker,
+                syncManifest: existingManifest,
+                outputRootURL: isSync ? outputURL : nil,
+                verbose: verbose, tracker: tracker,
+                progressHandler: progressHandler
+            )
+        }
+
+        // Set folder timestamps
+        try await setFolderTimestamps(hierarchy: hierarchy, outputURL: outputURL)
+
+        // Save sync manifest
+        if let syncTracker = syncTracker {
+            let finalManifest = await syncTracker.getManifest()
+            try finalManifest.save(to: outputURL)
+        }
+
+        let stats = await tracker.getStats()
+        let duration = Date().timeIntervalSince(startTime)
+
+        return ExportResult(
+            success: stats.failedNotes == 0,
+            exported: stats.completed,
+            skipped: notes.count - notesToExport.count,
+            failed: stats.failedNotes,
+            failedAttachments: stats.failedAttachments,
+            outputDirectory: outputURL.path,
+            format: format.fileExtension,
+            durationSeconds: duration
+        )
+    }
+
+    // MARK: - Concurrent Export
+
+    private func exportNotesConcurrently(
+        _ notesWithPaths: [(note: NotesNote, folderURL: URL)],
+        format: ExportFormat,
+        includeAttachments: Bool,
+        totalNotes: Int,
+        startTime: Date,
+        syncTracker: SyncManifestTracker?,
+        syncManifest: SyncManifest?,
+        outputRootURL: URL?,
+        verbose: Bool,
+        tracker: ExportProgressTracker,
+        progressHandler: @Sendable @escaping (Int, Int) -> Void
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            var iterator = notesWithPaths.makeIterator()
+            var activeTaskCount = 0
+
+            while activeTaskCount < maxConcurrentExports, let noteWithPath = iterator.next() {
+                let overridePath = syncManifest?.existingPath(for: noteWithPath.note.id)
+                group.addTask {
+                    await self.exportNoteSafelyWrapped(
+                        noteWithPath.note,
+                        toDirectory: noteWithPath.folderURL,
+                        format: format,
+                        includeAttachments: includeAttachments,
+                        tracker: tracker,
+                        syncTracker: syncTracker,
+                        overrideRelativePath: overridePath,
+                        outputRootURL: outputRootURL,
+                        verbose: verbose
+                    )
+                }
+                activeTaskCount += 1
+            }
+
+            for try await _ in group {
+                let stats = await tracker.getStats()
+                progressHandler(stats.completed + stats.failedNotes, totalNotes)
+
+                if let noteWithPath = iterator.next() {
+                    let overridePath = syncManifest?.existingPath(for: noteWithPath.note.id)
+                    group.addTask {
+                        await self.exportNoteSafelyWrapped(
+                            noteWithPath.note,
+                            toDirectory: noteWithPath.folderURL,
+                            format: format,
+                            includeAttachments: includeAttachments,
+                            tracker: tracker,
+                            syncTracker: syncTracker,
+                            overrideRelativePath: overridePath,
+                            outputRootURL: outputRootURL,
+                            verbose: verbose
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func exportNotesConcatenated(
+        _ notesWithPaths: [(note: NotesNote, folderURL: URL)],
+        format: ExportFormat,
+        includeAttachments: Bool,
+        outputURL: URL,
+        verbose: Bool,
+        tracker: ExportProgressTracker,
+        progressHandler: @Sendable @escaping (Int, Int) -> Void
+    ) async throws {
+        var contentParts: [String] = []
+        let total = notesWithPaths.count
+
+        for (index, noteWithPath) in notesWithPaths.enumerated() {
+            let note = noteWithPath.note
+            progressHandler(index, total)
+            do {
+                var attachmentPaths: [String: String] = [:]
+                if includeAttachments && note.hasAttachments {
+                    attachmentPaths = try await exportAttachmentsAndReturnPaths(
+                        note.attachments, toDirectory: outputURL,
+                        noteBaseName: note.sanitizedFileName,
+                        noteTitle: note.title,
+                        noteCreationDate: note.creationDate,
+                        noteModificationDate: note.modificationDate,
+                        tracker: tracker
+                    )
+                }
+                let content = try await generateContent(for: note, format: format, attachmentPaths: attachmentPaths, exportDirectory: outputURL)
+                contentParts.append(content)
+                if verbose { CLIOutput.writeStderr("✓ Processed: \(note.title)") }
+            } catch {
+                await tracker.noteFailed()
+                if verbose { CLIOutput.writeStderr("✗ Failed: \(note.title) — \(error.localizedDescription)") }
+            }
+        }
+
+        let separator: String
+        switch format {
+        case .html:     separator = "\n<hr style=\"page-break-after: always;\">\n"
+        case .markdown: separator = "\n\n---\n\n"
+        case .txt:      separator = "\n\n" + String(repeating: "=", count: 72) + "\n\n"
+        case .rtf:      separator = "\n\\page\n"
+        case .tex:      separator = "\n\n\\newpage\n\n"
+        case .pdf:      separator = ""  // unreachable — blocked upstream
+        }
+
+        let concatenated = contentParts.joined(separator: separator)
+        let filename = "Exported Notes.\(format.fileExtension)"
+        let fileURL = outputURL.appendingPathComponent(filename)
+        try concatenated.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Single Note Export
+
+    private func exportNoteSafelyWrapped(
+        _ note: NotesNote,
+        toDirectory directory: URL,
+        format: ExportFormat,
+        includeAttachments: Bool,
+        tracker: ExportProgressTracker,
+        syncTracker: SyncManifestTracker?,
+        overrideRelativePath: String?,
+        outputRootURL: URL?,
+        verbose: Bool
+    ) async {
+        do {
+            try await exportNoteSafely(
+                note, toDirectory: directory, format: format,
+                includeAttachments: includeAttachments,
+                tracker: tracker, syncTracker: syncTracker,
+                overrideRelativePath: overrideRelativePath,
+                outputRootURL: outputRootURL
+            )
+            _ = await tracker.noteCompleted()
+            if verbose { CLIOutput.writeStderr("✓ Exported: \(note.title)") }
+        } catch {
+            await tracker.noteFailed()
+            if verbose { CLIOutput.writeStderr("✗ Failed: \(note.title) — \(error.localizedDescription)") }
+        }
+    }
+
+    private func exportNoteSafely(
+        _ note: NotesNote,
+        toDirectory directory: URL,
+        format: ExportFormat,
+        includeAttachments: Bool,
+        tracker: ExportProgressTracker,
+        syncTracker: SyncManifestTracker?,
+        overrideRelativePath: String?,
+        outputRootURL: URL?
+    ) async throws {
+        try Task.checkCancellation()
+
+        let fileURL: URL
+        let uniqueBaseName: String
+
+        if let relativePath = overrideRelativePath, let rootURL = outputRootURL {
+            fileURL = rootURL.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            uniqueBaseName = fileURL.deletingPathExtension().lastPathComponent
+        } else {
+            let baseFilename: String
+            if configurations.addDateToFilename {
+                let formatter = DateFormatter()
+                formatter.dateFormat = configurations.filenameDateFormat.rawValue
+                let datePrefix = formatter.string(from: note.creationDate)
+                baseFilename = "\(datePrefix) \(note.sanitizedFileName)"
+            } else {
+                baseFilename = note.sanitizedFileName
+            }
+            let filename = generateUniqueFilename(baseName: baseFilename, extension: format.fileExtension, inDirectory: directory)
+            fileURL = directory.appendingPathComponent(filename)
+            uniqueBaseName = filename.replacingOccurrences(of: ".\(format.fileExtension)", with: "")
+        }
+
+        var attachmentPaths: [String: String] = [:]
+        if includeAttachments && note.hasAttachments {
+            try Task.checkCancellation()
+            attachmentPaths = try await exportAttachmentsAndReturnPaths(
+                note.attachments, toDirectory: directory,
+                noteBaseName: uniqueBaseName,
+                noteTitle: note.title,
+                noteCreationDate: note.creationDate,
+                noteModificationDate: note.modificationDate,
+                tracker: tracker
+            )
+        }
+
+        let content = try await generateContent(for: note, format: format, attachmentPaths: attachmentPaths, exportDirectory: directory)
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        try setFileTimestamps(fileURL, creationDate: note.creationDate, modificationDate: note.modificationDate)
+
+        if let syncTracker = syncTracker, let rootURL = outputRootURL {
+            let relativePath = fileURL.path.replacingOccurrences(of: rootURL.path + "/", with: "")
+            let attachmentRelPaths = attachmentPaths.values.map { path -> String in
+                let noteDir = directory.path.replacingOccurrences(of: rootURL.path + "/", with: "")
+                return noteDir.isEmpty ? path : "\(noteDir)/\(path)"
+            }
+            await syncTracker.recordExport(
+                noteId: note.id,
+                modificationDate: note.modificationDate,
+                exportedPath: relativePath,
+                attachmentPaths: attachmentRelPaths
+            )
+        }
+    }
+
+    // MARK: - Attachment Export
+
+    private func exportAttachmentsAndReturnPaths(
+        _ attachments: [NotesAttachment],
+        toDirectory directory: URL,
+        noteBaseName: String,
+        noteTitle: String,
+        noteCreationDate: Date,
+        noteModificationDate: Date,
+        tracker: ExportProgressTracker
+    ) async throws -> [String: String] {
+        var attachmentPaths: [String: String] = [:]
+
+        let nonFileAttachmentPrefixes = [
+            "com.apple.notes.table",
+            "com.apple.notes.inlinetextattachment",
+            "com.apple.notes.inlinehashtagattachment",
+            "com.apple.notes.inlinementionattachment",
+            "public.url"
+        ]
+
+        let fileAttachments = attachments.filter { attachment in
+            !nonFileAttachmentPrefixes.contains { attachment.typeUTI.hasPrefix($0) }
+        }
+
+        guard !fileAttachments.isEmpty else { return attachmentPaths }
+
+        let attachmentsURL = directory.appendingPathComponent("\(noteBaseName) (Attachments)")
+        try FileManager.default.createDirectory(at: attachmentsURL, withIntermediateDirectories: true)
+
+        var usedFilenames: [String: Int] = [:]
+
+        for attachment in fileAttachments {
+            try Task.checkCancellation()
+            do {
+                let data = try await repository.fetchAttachment(id: attachment.id)
+
+                let baseFilename: String
+                if let filename = attachment.filename {
+                    baseFilename = filename
+                } else if let fetchedFilename = await repository.fetchAttachmentFilename(id: attachment.id) {
+                    baseFilename = fetchedFilename
+                } else {
+                    baseFilename = "\(attachment.id).\(attachment.fileExtension ?? "bin")"
+                }
+
+                let finalFilename: String
+                if let count = usedFilenames[baseFilename] {
+                    let (name, ext) = splitFilename(baseFilename)
+                    finalFilename = "\(name) (\(count + 1)).\(ext)"
+                    usedFilenames[baseFilename] = count + 1
+                } else {
+                    finalFilename = baseFilename
+                    usedFilenames[baseFilename] = 1
+                }
+
+                let fileURL = attachmentsURL.appendingPathComponent(finalFilename)
+                try data.write(to: fileURL)
+                try setFileTimestamps(fileURL, creationDate: noteCreationDate, modificationDate: noteModificationDate)
+
+                let relativePath = "\(noteBaseName) (Attachments)/\(finalFilename)"
+                attachmentPaths[attachment.id] = relativePath
+            } catch {
+                await tracker.attachmentFailed()
+            }
+        }
+
+        if !fileAttachments.isEmpty {
+            try setFileTimestamps(attachmentsURL, creationDate: noteCreationDate, modificationDate: noteModificationDate)
+        }
+
+        return attachmentPaths
+    }
+
+    // MARK: - Content Generation
+
+    private func generateContent(
+        for note: NotesNote,
+        format: ExportFormat,
+        attachmentPaths: [String: String] = [:],
+        exportDirectory: URL? = nil
+    ) async throws -> String {
+        switch format {
+        case .html:
+            return try await generateHTML(for: note, attachmentPaths: attachmentPaths, exportDirectory: exportDirectory)
+        case .txt:
+            let html = try await generateHTML(for: note, attachmentPaths: attachmentPaths, exportDirectory: exportDirectory)
+            return makeNote(note, html: html).toPlainText()
+        case .markdown:
+            let html = try await generateHTML(for: note, attachmentPaths: attachmentPaths, exportDirectory: exportDirectory)
+            return makeNote(note, html: html).toMarkdown()
+        case .rtf:
+            let html = try await generateHTML(for: note, attachmentPaths: attachmentPaths, exportDirectory: exportDirectory)
+            return makeNote(note, html: html).toRTF(
+                fontFamily: configurations.rtf.fontFamily.rtfFontName,
+                fontSize: configurations.rtf.fontSizePoints
+            )
+        case .tex:
+            let html = try await generateHTML(for: note, attachmentPaths: attachmentPaths, exportDirectory: exportDirectory)
+            return makeNote(note, html: html).toLatex(template: configurations.latex.template)
+        case .pdf:
+            throw CLIError.unsupportedFormat(format)
+        }
+    }
+
+    private func makeNote(_ note: NotesNote, html: String) -> NotesNote {
+        NotesNote(
+            id: note.id, title: note.title, plaintext: note.plaintext,
+            htmlBody: html,
+            creationDate: note.creationDate, modificationDate: note.modificationDate,
+            folderId: note.folderId, accountId: note.accountId,
+            attachments: note.attachments
+        )
+    }
+
+    private func generateHTML(
+        for note: NotesNote,
+        attachmentPaths: [String: String] = [:],
+        exportDirectory: URL? = nil
+    ) async throws -> String {
+        let htmlConfig = configurations.html
+
+        let htmlBody: String
+        if let existingHTML = note.htmlBody {
+            htmlBody = existingHTML
+        } else {
+            do {
+                htmlBody = try await repository.generateHTML(forNoteId: note.id)
+            } catch {
+                // Fallback to plaintext
+                htmlBody = "<html><body><pre>\(note.plaintext.htmlEscaped)</pre></body></html>"
+            }
+        }
+
+        var processedHTML = htmlBody
+        if !note.attachments.isEmpty {
+            if let parserHandle = ane_open(databasePath) {
+                defer { ane_close(parserHandle) }
+                if let rawHandle = ane_get_sqlite_handle(parserHandle) {
+                    let database = OpaquePointer(rawHandle)
+                    let processor = HTMLAttachmentProcessor(database: database)
+                    processedHTML = processor.processHTML(
+                        html: htmlBody,
+                        attachments: note.attachments,
+                        attachmentPaths: attachmentPaths,
+                        exportDirectory: exportDirectory?.path,
+                        embedImages: htmlConfig.embedImagesInline,
+                        linkEmbeddedImages: htmlConfig.linkEmbeddedImages
+                    )
+                }
+            }
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+
+        let fontFamily = htmlConfig.fontFamily.cssFontStack
+        let fontSize = "\(htmlConfig.fontSizePoints)pt"
+        let marginValue = "\(htmlConfig.marginSize)\(htmlConfig.marginUnit.displayName)"
+
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <meta name="created" content="\(dateFormatter.string(from: note.creationDate))">
+            <meta name="modified" content="\(dateFormatter.string(from: note.modificationDate))">
+            <title>\(note.title.htmlEscaped)</title>
+            <style>
+                body {
+                    font-family: \(fontFamily);
+                    font-size: \(fontSize);
+                    max-width: 800px;
+                    margin: \(marginValue) auto;
+                    padding: 0 20px;
+                    line-height: 1.0;
+                }
+                h1, h2, h3, h4, h5, h6, p { margin: 0; padding: 0; line-height: 1.0; }
+                ul, ol { margin: 0; margin-left: 1.5em; padding: 0; padding-left: 0.5em; }
+                li { margin: 0; padding: 0; line-height: 1.0; }
+                img { max-width: 100%; }
+            </style>
+        </head>
+        <body>
+            <div class="content">
+                \(processedHTML)
+            </div>
+        </body>
+        </html>
+        """
+    }
+
+    // MARK: - Hierarchy Organisation
+
+    func organizeNotesByHierarchy(_ notes: [NotesNote]) async throws -> [String: [String: [NotesNote]]] {
+        var result: [String: [String: [NotesNote]]] = [:]
+
+        let accounts = try await repository.fetchAccounts()
+        let folders = try await repository.fetchFolders()
+
+        var accountLookup: [String: String] = [:]
+        for account in accounts { accountLookup[account.id] = account.name }
+
+        var folderLookup: [String: NotesFolder] = [:]
+        for folder in folders { folderLookup[folder.id] = folder }
+
+        for note in notes {
+            let accountName = accountLookup[note.accountId] ?? "Unknown Account"
+            let accountKey = sanitizeFilename(accountName)
+            let folderPath = buildFolderPath(folderId: note.folderId, folderLookup: folderLookup)
+
+            result[accountKey, default: [:]][folderPath, default: []].append(note)
+        }
+
+        return result
+    }
+
+    private func buildFolderPath(folderId: String, folderLookup: [String: NotesFolder]) -> String {
+        guard let folder = folderLookup[folderId] else { return sanitizeFilename("Unknown Folder") }
+
+        var components: [String] = [sanitizeFilename(folder.name)]
+        var currentParentId = folder.parentId
+        while let parentId = currentParentId, let parentFolder = folderLookup[parentId] {
+            components.insert(sanitizeFilename(parentFolder.name), at: 0)
+            currentParentId = parentFolder.parentId
+        }
+        return components.joined(separator: "/")
+    }
+
+    // MARK: - Helpers
+
+    private func setFileTimestamps(_ fileURL: URL, creationDate: Date, modificationDate: Date) throws {
+        let attributes: [FileAttributeKey: Any] = [
+            .creationDate: creationDate,
+            .modificationDate: modificationDate
+        ]
+        try FileManager.default.setAttributes(attributes, ofItemAtPath: fileURL.path)
+    }
+
+    private func setFolderTimestamps(hierarchy: [String: [String: [NotesNote]]], outputURL: URL) async throws {
+        for (accountName, folders) in hierarchy {
+            let accountURL = outputURL.appendingPathComponent(sanitizeFilename(accountName))
+            var accountOldest: Date?
+            var accountLatest: Date?
+
+            for (folderPath, notes) in folders {
+                guard !notes.isEmpty else { continue }
+                let folderURL = accountURL.appendingPathComponent(folderPath)
+                let oldest = notes.map { $0.creationDate }.min() ?? Date()
+                let latest = notes.map { $0.modificationDate }.max() ?? Date()
+                try setFileTimestamps(folderURL, creationDate: oldest, modificationDate: latest)
+                if accountOldest == nil || oldest < accountOldest! { accountOldest = oldest }
+                if accountLatest == nil || latest > accountLatest! { accountLatest = latest }
+            }
+            if let o = accountOldest, let l = accountLatest {
+                try setFileTimestamps(accountURL, creationDate: o, modificationDate: l)
+            }
+        }
+    }
+
+    func sanitizeFilename(_ name: String) -> String {
+        let invalidCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
+            .union(.newlines).union(.illegalCharacters).union(.controlCharacters)
+        return name.components(separatedBy: invalidCharacters).joined(separator: "_")
+    }
+
+    private func generateUniqueFilename(baseName: String, extension ext: String, inDirectory directory: URL) -> String {
+        let initial = "\(baseName).\(ext)"
+        if !FileManager.default.fileExists(atPath: directory.appendingPathComponent(initial).path) { return initial }
+        var counter = 2
+        while counter <= 10000 {
+            let candidate = "\(baseName) (\(counter)).\(ext)"
+            if !FileManager.default.fileExists(atPath: directory.appendingPathComponent(candidate).path) { return candidate }
+            counter += 1
+        }
+        return "\(baseName)_\(UUID().uuidString).\(ext)"
+    }
+
+    private func splitFilename(_ filename: String) -> (name: String, ext: String) {
+        if let lastDot = filename.lastIndex(of: "."), lastDot != filename.startIndex {
+            return (String(filename[..<lastDot]), String(filename[filename.index(after: lastDot)...]))
+        }
+        return (filename, "")
+    }
+
+    // MARK: - Repository Access (for list commands)
+
+    func fetchAccounts() async throws -> [NotesAccount] {
+        try await repository.fetchAccounts()
+    }
+
+    func fetchFolders() async throws -> [NotesFolder] {
+        try await repository.fetchFolders()
+    }
+
+    func fetchNotes() async throws -> [NotesNote] {
+        try await repository.fetchNotes()
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/CLIOutput.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/CLIOutput.swift
@@ -1,0 +1,86 @@
+//
+//  CLIOutput.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+// MARK: - Output Helpers
+
+enum CLIOutput {
+
+    private static let encoder: JSONEncoder = {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        enc.dateEncodingStrategy = .iso8601
+        return enc
+    }()
+
+    /// Write an Encodable value as pretty-printed JSON to stdout.
+    static func writeJSON<T: Encodable>(_ value: T) {
+        do {
+            let data = try encoder.encode(value)
+            print(String(data: data, encoding: .utf8) ?? "{}")
+        } catch {
+            writeError(CLIError.repositoryError("JSON encoding failed: \(error.localizedDescription)"))
+        }
+    }
+
+    /// Write a structured JSON error object to stderr and exit.
+    static func writeError(_ error: CLIError) {
+        let payload: [String: String] = [
+            "error": error.errorCode,
+            "message": error.message
+        ]
+        if let data = try? encoder.encode(payload),
+           let str = String(data: data, encoding: .utf8) {
+            fputs(str + "\n", stderr)
+        }
+    }
+
+    /// Write a plain-text progress line to stderr (visible but not captured by JSON consumers).
+    static func writeProgress(_ current: Int, _ total: Int, note: String? = nil) {
+        if let note = note {
+            fputs("[\(current)/\(total)] \(note)\n", stderr)
+        } else {
+            fputs("[\(current)/\(total)]\n", stderr)
+        }
+    }
+
+    /// Write an arbitrary message to stderr.
+    static func writeStderr(_ message: String) {
+        fputs(message + "\n", stderr)
+    }
+}
+
+// MARK: - ExportFormat CLI Extension
+
+extension ExportFormat {
+    /// Initialize from a CLI string (case-insensitive, accepts aliases).
+    init?(cliString: String) {
+        switch cliString.lowercased() {
+        case "html":             self = .html
+        case "md", "markdown":   self = .markdown
+        case "rtf":              self = .rtf
+        case "txt", "text":      self = .txt
+        case "tex", "latex":     self = .tex
+        case "pdf":              self = .pdf
+        default:                 return nil
+        }
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ExportCommand.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ExportCommand.swift
@@ -1,0 +1,254 @@
+//
+//  ExportCommand.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - export
+
+struct ExportCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "export",
+        abstract: "Export notes to files.",
+        discussion: "PDF is not supported in the CLI. Export as HTML and convert with a PDF printer or pandoc."
+    )
+
+    // Required
+    @Option(name: .shortAndLong, help: "Output directory (will be created if it does not exist).")
+    var output: String
+
+    @Option(name: .shortAndLong, help: "Export format: html, markdown (md), rtf, txt, tex.")
+    var format: String = "markdown"
+
+    // Note selection filters
+    @Option(name: .long, help: "Export only these note IDs (comma-separated).")
+    var notes: String?
+
+    @Option(name: .long, help: "Filter by account name (partial match, case-insensitive).")
+    var account: String?
+
+    @Option(name: .long, help: "Filter by folder name (partial match, case-insensitive).")
+    var folder: String?
+
+    @Option(name: .long, help: "Filter notes whose title contains this string (case-insensitive).")
+    var titleContains: String?
+
+    @Option(name: .long, help: "Include notes modified after this ISO 8601 date.")
+    var modifiedAfter: String?
+
+    @Option(name: .long, help: "Include notes modified before this ISO 8601 date.")
+    var modifiedBefore: String?
+
+    // Export options
+    @Flag(name: .long, help: "Skip exporting attachments.")
+    var noAttachments: Bool = false
+
+    @Flag(name: .long, help: "Add creation date prefix to filenames.")
+    var addDatePrefix: Bool = false
+
+    @Option(name: .long, help: "Date format for prefix: iso (yyyy-MM-dd), us (MM-dd-yyyy), eu (dd-MM-yyyy).")
+    var dateFormat: String = "iso"
+
+    @Flag(name: .long, help: "Concatenate all notes into a single output file.")
+    var concatenate: Bool = false
+
+    @Flag(name: .long, help: "Incremental sync: only export new or changed notes.")
+    var incremental: Bool = false
+
+    @Flag(name: .long, help: "Delete the sync manifest before exporting, forcing a full re-export. Only effective with --incremental.")
+    var resetSync: Bool = false
+
+    // HTML/content styling
+    @Option(name: .long, help: "Font family: system (default), serif, sans-serif, monospace.")
+    var fontFamily: String = "system"
+
+    @Option(name: .long, help: "Font size in points (default: 14).")
+    var fontSize: Double = 14.0
+
+    // Output control
+    @Flag(name: .shortAndLong, help: "Print per-note progress to stderr.")
+    var verbose: Bool = false
+
+    @OptionGroup var dbOptions: DatabaseOptions
+
+    func run() async throws {
+        // Validate format
+        guard let exportFormat = ExportFormat(cliString: format) else {
+            CLIOutput.writeError(.repositoryError("Unknown format '\(format)'. Valid formats: html, markdown, rtf, txt, tex."))
+            throw ExitCode(2)
+        }
+
+        guard exportFormat != .pdf else {
+            CLIOutput.writeError(.unsupportedFormat(.pdf))
+            throw ExitCode(2)
+        }
+
+        // Resolve and create output directory
+        let outputURL = URL(fileURLWithPath: (output as NSString).expandingTildeInPath).standardizedFileURL
+        do {
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+        } catch {
+            CLIOutput.writeError(.invalidOutputDirectory(output))
+            throw ExitCode(2)
+        }
+
+        // Build configurations
+        var configs = ExportConfigurations.default
+        configs.includeAttachments = !noAttachments
+        configs.addDateToFilename = addDatePrefix
+        configs.concatenateOutput = concatenate
+        configs.incrementalSync = incremental
+
+        // Delete sync manifest when --reset-sync is requested (must happen before engine loads it)
+        if resetSync {
+            let manifestURL = outputURL.appendingPathComponent(SyncManifest.filename)
+            try? FileManager.default.removeItem(at: manifestURL)
+            if verbose { CLIOutput.writeStderr("Sync manifest deleted; next export will be a full re-export.") }
+        }
+
+        // Map date format
+        switch dateFormat.lowercased() {
+        case "us":   configs.filenameDateFormat = .usDate
+        case "eu":   configs.filenameDateFormat = .euDate
+        default:     configs.filenameDateFormat = .iso
+        }
+
+        // Map font family (handle hyphenated names like "sans-serif" → "Sans-Serif")
+        let normalizedFontFamily = fontFamily.split(separator: "-")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: "-")
+        if let ff = HTMLConfiguration.FontFamily(rawValue: normalizedFontFamily) {
+            configs.html = HTMLConfiguration(
+                fontSizePoints: fontSize,
+                fontFamily: ff,
+                marginSize: configs.html.marginSize,
+                marginUnit: configs.html.marginUnit,
+                embedImagesInline: configs.html.embedImagesInline,
+                linkEmbeddedImages: configs.html.linkEmbeddedImages
+            )
+        } else {
+            configs.html = HTMLConfiguration(
+                fontSizePoints: fontSize,
+                fontFamily: .system,
+                marginSize: configs.html.marginSize,
+                marginUnit: configs.html.marginUnit,
+                embedImagesInline: configs.html.embedImagesInline,
+                linkEmbeddedImages: configs.html.linkEmbeddedImages
+            )
+        }
+
+        let engine = CLIExportEngine(databasePath: dbOptions.db, configurations: configs)
+
+        // Fetch all notes then apply filters
+        let (accounts, folders, allNotes): ([NotesAccount], [NotesFolder], [NotesNote])
+        do {
+            async let a = engine.fetchAccounts()
+            async let f = engine.fetchFolders()
+            async let n = engine.fetchNotes()
+            (accounts, folders, allNotes) = try await (a, f, n)
+        } catch {
+            CLIOutput.writeError(.databaseUnavailable)
+            throw ExitCode(CLIError.databaseUnavailable.exitCode)
+        }
+
+        var filtered = allNotes
+
+        // Filter by explicit note IDs
+        if let noteIdsStr = notes {
+            let ids = Set(noteIdsStr.split(separator: ",").map { String($0.trimmingCharacters(in: .whitespaces)) })
+            filtered = filtered.filter { ids.contains($0.id) }
+        }
+
+        if let accountFilter = account?.lowercased() {
+            let matchingIds = accounts.filter { $0.name.lowercased().contains(accountFilter) }.map { $0.id }
+            filtered = filtered.filter { matchingIds.contains($0.accountId) }
+        }
+
+        if let folderFilter = folder?.lowercased() {
+            let matchingIds = folders.filter { $0.name.lowercased().contains(folderFilter) }.map { $0.id }
+            filtered = filtered.filter { matchingIds.contains($0.folderId) }
+        }
+
+        if let tc = titleContains?.lowercased() {
+            filtered = filtered.filter { $0.title.lowercased().contains(tc) }
+        }
+
+        if let dateStr = modifiedAfter, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate > date }
+        }
+        if let dateStr = modifiedBefore, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate < date }
+        }
+
+        if filtered.isEmpty {
+            CLIOutput.writeJSON(
+                CLIExportEngine.ExportResult(
+                    success: true,
+                    exported: 0,
+                    skipped: 0,
+                    failed: 0,
+                    failedAttachments: 0,
+                    outputDirectory: outputURL.path,
+                    format: exportFormat.fileExtension,
+                    durationSeconds: 0.0
+                )
+            )
+            return
+        }
+
+        if verbose { CLIOutput.writeStderr("Exporting \(filtered.count) notes as \(exportFormat.rawValue) to \(outputURL.path)") }
+
+        do {
+            let result = try await engine.exportNotes(
+                filtered,
+                toDirectory: outputURL,
+                format: exportFormat,
+                includeAttachments: !noAttachments,
+                verbose: verbose,
+                progressHandler: { current, total in
+                    CLIOutput.writeProgress(current, total)
+                }
+            )
+            CLIOutput.writeJSON(result)
+            if result.failed > 0 {
+                throw ExitCode(1)
+            }
+        } catch let error as CLIError {
+            CLIOutput.writeError(error)
+            throw ExitCode(error.exitCode)
+        }
+    }
+
+    // MARK: - Date Parsing
+
+    private func parseDate(_ string: String) -> Date? {
+        let isoFull = ISO8601DateFormatter()
+        isoFull.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFull.date(from: string) { return date }
+
+        let isoBasic = ISO8601DateFormatter()
+        if let date = isoBasic.date(from: string) { return date }
+
+        let dateOnly = DateFormatter()
+        dateOnly.dateFormat = "yyyy-MM-dd"
+        dateOnly.timeZone = TimeZone(identifier: "UTC")
+        return dateOnly.date(from: string)
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListAccountsCommand.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListAccountsCommand.swift
@@ -1,0 +1,68 @@
+//
+//  ListAccountsCommand.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - list-accounts
+
+struct ListAccountsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list-accounts",
+        abstract: "List all Notes accounts."
+    )
+
+    @OptionGroup var dbOptions: DatabaseOptions
+    @OptionGroup var formatOptions: FormatOptions
+
+    func run() async throws {
+        let engine = CLIExportEngine(databasePath: dbOptions.db)
+
+        let accounts: [NotesAccount]
+        do {
+            accounts = try await engine.fetchAccounts()
+        } catch {
+            CLIOutput.writeError(.databaseUnavailable)
+            throw ExitCode(CLIError.databaseUnavailable.exitCode)
+        }
+
+        if formatOptions.isJSON {
+            struct AccountJSON: Encodable {
+                let id: String
+                let name: String
+                let type: String
+            }
+            struct Output: Encodable {
+                let accounts: [AccountJSON]
+                let count: Int
+            }
+            let output = Output(
+                accounts: accounts.map { AccountJSON(id: $0.id, name: $0.name, type: $0.accountType.displayName) },
+                count: accounts.count
+            )
+            CLIOutput.writeJSON(output)
+        } else {
+            for account in accounts {
+                print("\(account.id)\t\(account.name)\t(\(account.accountType.displayName))")
+            }
+            print("Total: \(accounts.count)")
+        }
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListFoldersCommand.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListFoldersCommand.swift
@@ -1,0 +1,100 @@
+//
+//  ListFoldersCommand.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - list-folders
+
+struct ListFoldersCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list-folders",
+        abstract: "List all Notes folders."
+    )
+
+    @Option(name: .long, help: "Filter folders by account name (partial match, case-insensitive).")
+    var account: String?
+
+    @OptionGroup var dbOptions: DatabaseOptions
+    @OptionGroup var formatOptions: FormatOptions
+
+    func run() async throws {
+        let engine = CLIExportEngine(databasePath: dbOptions.db)
+
+        let (accounts, folders): ([NotesAccount], [NotesFolder])
+        do {
+            async let a = engine.fetchAccounts()
+            async let f = engine.fetchFolders()
+            (accounts, folders) = try await (a, f)
+        } catch {
+            CLIOutput.writeError(.databaseUnavailable)
+            throw ExitCode(CLIError.databaseUnavailable.exitCode)
+        }
+
+        // Build account lookup
+        var accountLookup: [String: String] = [:]
+        for acct in accounts { accountLookup[acct.id] = acct.name }
+
+        // Filter by account if requested
+        let filtered: [NotesFolder]
+        if let accountFilter = account?.lowercased() {
+            let matchingAccountIds = accounts
+                .filter { $0.name.lowercased().contains(accountFilter) }
+                .map { $0.id }
+            filtered = folders.filter { matchingAccountIds.contains($0.accountId) }
+        } else {
+            filtered = folders
+        }
+
+        if formatOptions.isJSON {
+            struct FolderJSON: Encodable {
+                let id: String
+                let name: String
+                let parentId: String?
+                let accountId: String
+                let accountName: String
+            }
+            struct Output: Encodable {
+                let folders: [FolderJSON]
+                let count: Int
+            }
+            let output = Output(
+                folders: filtered.map { folder in
+                    FolderJSON(
+                        id: folder.id,
+                        name: folder.name,
+                        parentId: folder.parentId,
+                        accountId: folder.accountId,
+                        accountName: accountLookup[folder.accountId] ?? "Unknown"
+                    )
+                },
+                count: filtered.count
+            )
+            CLIOutput.writeJSON(output)
+        } else {
+            for folder in filtered {
+                let accountName = accountLookup[folder.accountId] ?? "Unknown"
+                let parentInfo = folder.parentId.map { " (parent: \($0))" } ?? ""
+                print("\(folder.id)\t\(folder.name)\t[\(accountName)]\(parentInfo)")
+            }
+            print("Total: \(filtered.count)")
+        }
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListNotesCommand.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/ListNotesCommand.swift
@@ -1,0 +1,188 @@
+//
+//  ListNotesCommand.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - list-notes
+
+struct ListNotesCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list-notes",
+        abstract: "List Notes with optional filtering."
+    )
+
+    @Option(name: .long, help: "Filter by account name (partial match, case-insensitive).")
+    var account: String?
+
+    @Option(name: .long, help: "Filter by folder name (partial match, case-insensitive).")
+    var folder: String?
+
+    @Option(name: .long, help: "Filter notes whose title contains this string (case-insensitive).")
+    var titleContains: String?
+
+    @Option(name: .long, help: "Include notes modified after this ISO 8601 date (e.g. 2025-01-01 or 2025-01-01T00:00:00Z).")
+    var modifiedAfter: String?
+
+    @Option(name: .long, help: "Include notes modified before this ISO 8601 date.")
+    var modifiedBefore: String?
+
+    @Option(name: .long, help: "Include notes created after this ISO 8601 date.")
+    var createdAfter: String?
+
+    @Option(name: .long, help: "Include notes created before this ISO 8601 date.")
+    var createdBefore: String?
+
+    @Option(name: .shortAndLong, help: "Sort order: name, date-modified (default), date-created.")
+    var sort: String = "date-modified"
+
+    @Flag(name: .long, help: "Include plaintext content of each note in the output (may be large).")
+    var includeContent: Bool = false
+
+    @OptionGroup var dbOptions: DatabaseOptions
+    @OptionGroup var formatOptions: FormatOptions
+
+    func run() async throws {
+        let engine = CLIExportEngine(databasePath: dbOptions.db)
+
+        let (accounts, folders, notes): ([NotesAccount], [NotesFolder], [NotesNote])
+        do {
+            async let a = engine.fetchAccounts()
+            async let f = engine.fetchFolders()
+            async let n = engine.fetchNotes()
+            (accounts, folders, notes) = try await (a, f, n)
+        } catch {
+            CLIOutput.writeError(.databaseUnavailable)
+            throw ExitCode(CLIError.databaseUnavailable.exitCode)
+        }
+
+        var accountLookup: [String: String] = [:]
+        for acct in accounts { accountLookup[acct.id] = acct.name }
+
+        var folderLookup: [String: NotesFolder] = [:]
+        for fld in folders { folderLookup[fld.id] = fld }
+
+        // Apply filters
+        var filtered = notes
+
+        if let accountFilter = account?.lowercased() {
+            let matchingIds = accounts.filter { $0.name.lowercased().contains(accountFilter) }.map { $0.id }
+            filtered = filtered.filter { matchingIds.contains($0.accountId) }
+        }
+
+        if let folderFilter = folder?.lowercased() {
+            let matchingIds = folders.filter { $0.name.lowercased().contains(folderFilter) }.map { $0.id }
+            filtered = filtered.filter { matchingIds.contains($0.folderId) }
+        }
+
+        if let tc = titleContains?.lowercased() {
+            filtered = filtered.filter { $0.title.lowercased().contains(tc) }
+        }
+
+        if let dateStr = modifiedAfter, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate > date }
+        }
+        if let dateStr = modifiedBefore, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate < date }
+        }
+        if let dateStr = createdAfter, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.creationDate > date }
+        }
+        if let dateStr = createdBefore, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.creationDate < date }
+        }
+
+        // Apply sort
+        switch sort.lowercased() {
+        case "name":
+            filtered.sort { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        case "date-created":
+            filtered.sort { $0.creationDate > $1.creationDate }
+        default: // date-modified
+            filtered.sort { $0.modificationDate > $1.modificationDate }
+        }
+
+        if formatOptions.isJSON {
+            struct NoteJSON: Encodable {
+                let id: String
+                let title: String
+                let folderId: String
+                let folderName: String
+                let accountId: String
+                let accountName: String
+                let creationDate: Date
+                let modificationDate: Date
+                let attachmentCount: Int
+                let plaintext: String?
+            }
+            struct Output: Encodable {
+                let notes: [NoteJSON]
+                let count: Int
+            }
+            let output = Output(
+                notes: filtered.map { note in
+                    NoteJSON(
+                        id: note.id,
+                        title: note.title,
+                        folderId: note.folderId,
+                        folderName: folderLookup[note.folderId]?.name ?? "Unknown",
+                        accountId: note.accountId,
+                        accountName: accountLookup[note.accountId] ?? "Unknown",
+                        creationDate: note.creationDate,
+                        modificationDate: note.modificationDate,
+                        attachmentCount: note.attachments.count,
+                        plaintext: includeContent ? note.plaintext : nil
+                    )
+                },
+                count: filtered.count
+            )
+            CLIOutput.writeJSON(output)
+        } else {
+            for note in filtered {
+                let accountName = accountLookup[note.accountId] ?? "Unknown"
+                let folderName = folderLookup[note.folderId]?.name ?? "Unknown"
+                print("\(note.id)\t\(note.title)\t[\(accountName)/\(folderName)]")
+                if includeContent {
+                    print(note.plaintext)
+                    print("---")
+                }
+            }
+            print("Total: \(filtered.count)")
+        }
+    }
+
+    // MARK: - Date Parsing
+
+    private func parseDate(_ string: String) -> Date? {
+        // Try full ISO 8601 with time first
+        let isoFull = ISO8601DateFormatter()
+        isoFull.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFull.date(from: string) { return date }
+
+        let isoBasic = ISO8601DateFormatter()
+        if let date = isoBasic.date(from: string) { return date }
+
+        // Try date-only (yyyy-MM-dd) — interpret as start of day UTC
+        let dateOnly = DateFormatter()
+        dateOnly.dateFormat = "yyyy-MM-dd"
+        dateOnly.timeZone = TimeZone(identifier: "UTC")
+        return dateOnly.date(from: string)
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/SyncStatusCommand.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/Commands/SyncStatusCommand.swift
@@ -1,0 +1,79 @@
+//
+//  SyncStatusCommand.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - sync-status
+
+struct SyncStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "sync-status",
+        abstract: "Show the incremental sync state for an output directory.",
+        discussion: """
+        Reads AppleNotesExportSyncWatermark.json from the output directory and
+        reports when the last sync ran and how many notes are tracked.
+        Does not open the Notes database.
+
+        To reset sync state, delete the manifest file or use:
+          notes-export export --output <dir> --incremental --reset-sync
+        """
+    )
+
+    @Option(name: .shortAndLong, help: "Output directory to inspect.")
+    var output: String
+
+    func run() async throws {
+        let outputURL = URL(fileURLWithPath: (output as NSString).expandingTildeInPath).standardizedFileURL
+        let manifestURL = outputURL.appendingPathComponent(SyncManifest.filename)
+
+        struct NoManifestResponse: Encodable {
+            let manifestFound: Bool
+            let outputDirectory: String
+            let manifestPath: String
+        }
+
+        struct ManifestResponse: Encodable {
+            let manifestFound: Bool
+            let lastSync: String
+            let trackedNotes: Int
+            let manifestPath: String
+        }
+
+        guard let manifest = SyncManifest.load(from: outputURL) else {
+            CLIOutput.writeJSON(NoManifestResponse(
+                manifestFound: false,
+                outputDirectory: outputURL.path,
+                manifestPath: manifestURL.path
+            ))
+            return
+        }
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        CLIOutput.writeJSON(ManifestResponse(
+            manifestFound: true,
+            lastSync: isoFormatter.string(from: manifest.lastSync),
+            trackedNotes: manifest.notes.count,
+            manifestPath: manifestURL.path
+        ))
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter CLI/NotesExportCLI.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter CLI/NotesExportCLI.swift
@@ -1,0 +1,62 @@
+//
+//  NotesExportCLI.swift
+//  Apple Notes Exporter CLI
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import ArgumentParser
+import Foundation
+
+// MARK: - Root Command
+
+@main
+struct NotesExportCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "notes-export",
+        abstract: "Export and query Apple Notes from the terminal.",
+        discussion: """
+        Requires Full Disk Access for the terminal process.
+        Grant it in System Settings → Privacy & Security → Full Disk Access.
+
+        All output is JSON on stdout; progress and errors go to stderr.
+        """,
+        version: "1.1.0",
+        subcommands: [
+            ListAccountsCommand.self,
+            ListFoldersCommand.self,
+            ListNotesCommand.self,
+            ExportCommand.self,
+            SyncStatusCommand.self,
+        ]
+    )
+}
+
+// MARK: - Shared Options
+
+/// Options used by every subcommand for database path override.
+struct DatabaseOptions: ParsableArguments {
+    @Option(name: .long, help: "Path to NoteStore.sqlite (default: system Notes database).")
+    var db: String = "\(NSHomeDirectory())/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"
+}
+
+/// Options used by list commands for output format selection.
+struct FormatOptions: ParsableArguments {
+    @Option(name: .shortAndLong, help: "Output format: json (default) or text.")
+    var format: String = "json"
+
+    var isJSON: Bool { format.lowercased() != "text" }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter MCP/AppleNotesExporterMCP.entitlements
+++ b/Apple Notes Exporter/Apple Notes Exporter MCP/AppleNotesExporterMCP.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<false/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<false/>
+	<key>com.apple.security.cs.debugger</key>
+	<false/>
+</dict>
+</plist>

--- a/Apple Notes Exporter/Apple Notes Exporter MCP/MCPToolHandlers.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter MCP/MCPToolHandlers.swift
@@ -1,0 +1,467 @@
+//
+//  MCPToolHandlers.swift
+//  Apple Notes Exporter MCP
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import MCP
+
+// MARK: - Tool Handlers
+
+enum MCPToolHandlers {
+
+    // MARK: - Tool Definitions
+
+    static let allTools: [Tool] = [
+        Tool(
+            name: "list_accounts",
+            description: "List all Apple Notes accounts (iCloud, On My Mac, Exchange, etc.).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:])
+            ])
+        ),
+        Tool(
+            name: "list_folders",
+            description: "List Apple Notes folders, optionally filtered by account.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "account": .object([
+                        "type": .string("string"),
+                        "description": .string("Account name filter (partial match, case-insensitive).")
+                    ])
+                ])
+            ])
+        ),
+        Tool(
+            name: "list_notes",
+            description: "List notes with optional filtering and sorting. Use include_content to embed plaintext.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "account": .object(["type": .string("string"),
+                        "description": .string("Account name filter (partial match).")]),
+                    "folder": .object(["type": .string("string"),
+                        "description": .string("Folder name filter (partial match).")]),
+                    "title_contains": .object(["type": .string("string"),
+                        "description": .string("Title substring filter (case-insensitive).")]),
+                    "modified_after": .object(["type": .string("string"),
+                        "description": .string("ISO 8601 date — return notes modified after this date.")]),
+                    "modified_before": .object(["type": .string("string"),
+                        "description": .string("ISO 8601 date — return notes modified before this date.")]),
+                    "sort": .object([
+                        "type": .string("string"),
+                        "description": .string("Sort order."),
+                        "enum": .array([.string("name"), .string("date-modified"), .string("date-created")])
+                    ]),
+                    "include_content": .object(["type": .string("boolean"),
+                        "description": .string("Include plaintext body of each note in the response.")])
+                ])
+            ])
+        ),
+        Tool(
+            name: "export_notes",
+            description: "Export notes to files. PDF is not supported; use html and convert if needed.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "output": .object(["type": .string("string"),
+                        "description": .string("Output directory path (created if absent).")]),
+                    "format": .object([
+                        "type": .string("string"),
+                        "description": .string("Export format."),
+                        "enum": .array([.string("html"), .string("markdown"), .string("rtf"), .string("txt"), .string("tex")])
+                    ]),
+                    "notes": .object(["type": .string("string"),
+                        "description": .string("Comma-separated note IDs to export (omit to export all matching).")]),
+                    "account": .object(["type": .string("string"),
+                        "description": .string("Account name filter (partial match).")]),
+                    "folder": .object(["type": .string("string"),
+                        "description": .string("Folder name filter (partial match).")]),
+                    "title_contains": .object(["type": .string("string"),
+                        "description": .string("Title substring filter.")]),
+                    "modified_after": .object(["type": .string("string"),
+                        "description": .string("ISO 8601 date — export notes modified after this date.")]),
+                    "modified_before": .object(["type": .string("string"),
+                        "description": .string("ISO 8601 date — export notes modified before this date.")]),
+                    "incremental": .object(["type": .string("boolean"),
+                        "description": .string("Only export new or changed notes (requires output directory).")]),
+                    "reset_sync": .object(["type": .string("boolean"),
+                        "description": .string("Delete the sync manifest before exporting, forcing a full re-export.")]),
+                    "no_attachments": .object(["type": .string("boolean"),
+                        "description": .string("Skip exporting attachments.")]),
+                    "add_date_prefix": .object(["type": .string("boolean"),
+                        "description": .string("Prefix filenames with the note creation date.")]),
+                    "font_family": .object([
+                        "type": .string("string"),
+                        "description": .string("Font family for HTML/RTF output."),
+                        "enum": .array([.string("System"), .string("Serif"), .string("Sans-Serif"), .string("Monospace")])
+                    ]),
+                    "font_size": .object(["type": .string("number"),
+                        "description": .string("Font size in points (default: 14).")])
+                ]),
+                "required": .array([.string("output"), .string("format")])
+            ])
+        ),
+        Tool(
+            name: "sync_status",
+            description: "Show the incremental sync state for an output directory. Does not open the Notes database.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "output": .object(["type": .string("string"),
+                        "description": .string("Output directory to inspect.")])
+                ]),
+                "required": .array([.string("output")])
+            ])
+        )
+    ]
+
+    // MARK: - Dispatcher
+
+    static func dispatch(params: CallTool.Parameters) async -> CallTool.Result {
+        let args = params.arguments ?? [:]
+        do {
+            switch params.name {
+            case "list_accounts":  return try await handleListAccounts(args: args)
+            case "list_folders":   return try await handleListFolders(args: args)
+            case "list_notes":     return try await handleListNotes(args: args)
+            case "export_notes":   return try await handleExportNotes(args: args)
+            case "sync_status":    return try handleSyncStatus(args: args)
+            default:
+                return errorText("Unknown tool '\(params.name)'.")
+            }
+        } catch let error as CLIError {
+            return errorText(error.message)
+        } catch {
+            return errorText(error.localizedDescription)
+        }
+    }
+
+    // MARK: - list_accounts
+
+    private static func handleListAccounts(args: [String: Value]) async throws -> CallTool.Result {
+        let engine = CLIExportEngine()
+        let accounts = try await engine.fetchAccounts()
+
+        struct AccountDTO: Encodable {
+            let id: String
+            let name: String
+            let type: String
+        }
+        struct Response: Encodable { let accounts: [AccountDTO]; let count: Int }
+
+        let dtos = accounts.map {
+            AccountDTO(id: $0.id, name: $0.name, type: String(describing: $0.accountType))
+        }
+        return jsonText(Response(accounts: dtos, count: dtos.count))
+    }
+
+    // MARK: - list_folders
+
+    private static func handleListFolders(args: [String: Value]) async throws -> CallTool.Result {
+        let engine = CLIExportEngine()
+        async let allAccounts = engine.fetchAccounts()
+        async let allFolders  = engine.fetchFolders()
+        let (accounts, folders) = try await (allAccounts, allFolders)
+
+        var filtered = folders
+        if let accountFilter = args["account"]?.stringValue?.lowercased() {
+            let matchingIds = accounts.filter { $0.name.lowercased().contains(accountFilter) }.map { $0.id }
+            filtered = filtered.filter { matchingIds.contains($0.accountId) }
+        }
+
+        struct FolderDTO: Encodable {
+            let id: String
+            let name: String
+            let parentId: String?
+            let accountId: String
+            let accountName: String
+        }
+        struct Response: Encodable { let folders: [FolderDTO]; let count: Int }
+        
+        let accountLookup = Swift.Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0.name) })
+        let dtos = filtered.map {
+            FolderDTO(id: $0.id, name: $0.name, parentId: $0.parentId,
+                      accountId: $0.accountId, accountName: accountLookup[$0.accountId] ?? "")
+        }
+        return jsonText(Response(folders: dtos, count: dtos.count))
+    }
+
+    // MARK: - list_notes
+
+    private static func handleListNotes(args: [String: Value]) async throws -> CallTool.Result {
+        let engine = CLIExportEngine()
+        async let allAccounts = engine.fetchAccounts()
+        async let allFolders  = engine.fetchFolders()
+        async let allNotes    = engine.fetchNotes()
+        let (accounts, folders, notes) = try await (allAccounts, allFolders, allNotes)
+
+        var filtered = notes
+
+        if let accountFilter = args["account"]?.stringValue?.lowercased() {
+            let ids = accounts.filter { $0.name.lowercased().contains(accountFilter) }.map { $0.id }
+            filtered = filtered.filter { ids.contains($0.accountId) }
+        }
+        if let folderFilter = args["folder"]?.stringValue?.lowercased() {
+            let ids = folders.filter { $0.name.lowercased().contains(folderFilter) }.map { $0.id }
+            filtered = filtered.filter { ids.contains($0.folderId) }
+        }
+        if let tc = args["title_contains"]?.stringValue?.lowercased() {
+            filtered = filtered.filter { $0.title.lowercased().contains(tc) }
+        }
+        if let dateStr = args["modified_after"]?.stringValue, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate > date }
+        }
+        if let dateStr = args["modified_before"]?.stringValue, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate < date }
+        }
+
+        let sortStr = args["sort"]?.stringValue ?? "date-modified"
+        switch sortStr {
+        case "name":          filtered.sort { $0.title.localizedCompare($1.title) == .orderedAscending }
+        case "date-created":  filtered.sort { $0.creationDate > $1.creationDate }
+        default:              filtered.sort { $0.modificationDate > $1.modificationDate }
+        }
+
+        let includeContent = args["include_content"]?.boolValue ?? false
+        let accountLookup = Swift.Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0.name) })
+        let folderLookup  = Swift.Dictionary(uniqueKeysWithValues: folders.map  { ($0.id, $0.name) })
+
+        struct NoteDTO: Encodable {
+            let id: String
+            let title: String
+            let folderId: String
+            let folderName: String
+            let accountId: String
+            let accountName: String
+            let creationDate: Date
+            let modificationDate: Date
+            let attachmentCount: Int
+            let plaintext: String?
+        }
+        struct Response: Encodable {
+            let notes: [NoteDTO]
+            let count: Int
+        }
+
+        let dtos = filtered.map {
+            NoteDTO(
+                id: $0.id, title: $0.title,
+                folderId: $0.folderId, folderName: folderLookup[$0.folderId] ?? "",
+                accountId: $0.accountId, accountName: accountLookup[$0.accountId] ?? "",
+                creationDate: $0.creationDate, modificationDate: $0.modificationDate,
+                attachmentCount: $0.attachments.count,
+                plaintext: includeContent ? $0.plaintext : nil
+            )
+        }
+        return jsonText(Response(notes: dtos, count: dtos.count))
+    }
+
+    // MARK: - export_notes
+
+    private static func handleExportNotes(args: [String: Value]) async throws -> CallTool.Result {
+        guard let outputStr = args["output"]?.stringValue else {
+            return errorText("Missing required argument 'output'.")
+        }
+        guard let formatStr = args["format"]?.stringValue,
+              let exportFormat = ExportFormat(cliString: formatStr) else {
+            return errorText("Missing or invalid 'format'. Valid values: html, markdown, rtf, txt, tex.")
+        }
+        guard exportFormat != .pdf else {
+            return errorText("PDF is not supported. Export as HTML and convert with a PDF printer or pandoc.")
+        }
+
+        let outputURL = URL(fileURLWithPath: (outputStr as NSString).expandingTildeInPath).standardizedFileURL
+        do {
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+        } catch {
+            return errorText("Cannot create output directory '\(outputStr)'.")
+        }
+
+        // Build configurations
+        var configs = ExportConfigurations.default
+        configs.includeAttachments = !(args["no_attachments"]?.boolValue ?? false)
+        configs.addDateToFilename  = args["add_date_prefix"]?.boolValue ?? false
+        configs.incrementalSync    = args["incremental"]?.boolValue ?? false
+
+        if let ff = args["font_family"]?.stringValue,
+           let fontFamily = HTMLConfiguration.FontFamily(rawValue: ff) {
+            configs.html = HTMLConfiguration(
+                fontSizePoints: args["font_size"]?.doubleValue ?? configs.html.fontSizePoints,
+                fontFamily: fontFamily,
+                marginSize: configs.html.marginSize,
+                marginUnit: configs.html.marginUnit,
+                embedImagesInline: configs.html.embedImagesInline,
+                linkEmbeddedImages: configs.html.linkEmbeddedImages
+            )
+        } else if let size = args["font_size"]?.doubleValue {
+            configs.html = HTMLConfiguration(
+                fontSizePoints: size,
+                fontFamily: configs.html.fontFamily,
+                marginSize: configs.html.marginSize,
+                marginUnit: configs.html.marginUnit,
+                embedImagesInline: configs.html.embedImagesInline,
+                linkEmbeddedImages: configs.html.linkEmbeddedImages
+            )
+        }
+
+        // Reset sync manifest if requested
+        if args["reset_sync"]?.boolValue == true {
+            let manifestURL = outputURL.appendingPathComponent(SyncManifest.filename)
+            try? FileManager.default.removeItem(at: manifestURL)
+        }
+
+        let engine = CLIExportEngine(configurations: configs)
+
+        // Fetch and filter
+        let (accounts, folders, allNotes): ([NotesAccount], [NotesFolder], [NotesNote])
+        do {
+            async let a = engine.fetchAccounts()
+            async let f = engine.fetchFolders()
+            async let n = engine.fetchNotes()
+            (accounts, folders, allNotes) = try await (a, f, n)
+        } catch {
+            return errorText("Cannot read the Notes database. Grant Full Disk Access to the process running this MCP server in System Settings → Privacy & Security → Full Disk Access.")
+        }
+
+        var filtered = allNotes
+
+        if let noteIdsStr = args["notes"]?.stringValue {
+            let ids = Set(noteIdsStr.split(separator: ",").map { String($0.trimmingCharacters(in: .whitespaces)) })
+            filtered = filtered.filter { ids.contains($0.id) }
+        }
+        if let accountFilter = args["account"]?.stringValue?.lowercased() {
+            let ids = accounts.filter { $0.name.lowercased().contains(accountFilter) }.map { $0.id }
+            filtered = filtered.filter { ids.contains($0.accountId) }
+        }
+        if let folderFilter = args["folder"]?.stringValue?.lowercased() {
+            let ids = folders.filter { $0.name.lowercased().contains(folderFilter) }.map { $0.id }
+            filtered = filtered.filter { ids.contains($0.folderId) }
+        }
+        if let tc = args["title_contains"]?.stringValue?.lowercased() {
+            filtered = filtered.filter { $0.title.lowercased().contains(tc) }
+        }
+        if let dateStr = args["modified_after"]?.stringValue, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate > date }
+        }
+        if let dateStr = args["modified_before"]?.stringValue, let date = parseDate(dateStr) {
+            filtered = filtered.filter { $0.modificationDate < date }
+        }
+
+        if filtered.isEmpty {
+            struct EmptyResult: Encodable {
+                let success: Bool
+                let exported: Int
+                let skipped: Int
+                let failed: Int
+                let failedAttachments: Int
+                let outputDirectory: String
+                let format: String
+                let durationSeconds: Double
+                let message: String
+            }
+            return jsonText(EmptyResult(
+                success: true, exported: 0, skipped: 0, failed: 0, failedAttachments: 0,
+                outputDirectory: outputURL.path, format: exportFormat.fileExtension,
+                durationSeconds: 0.0, message: "No notes matched the specified criteria."
+            ))
+        }
+
+        do {
+            let result = try await engine.exportNotes(
+                filtered,
+                toDirectory: outputURL,
+                format: exportFormat,
+                includeAttachments: configs.includeAttachments,
+                verbose: false,
+                progressHandler: { _, _ in }
+            )
+            return jsonText(result)
+        } catch let error as CLIError {
+            return errorText(error.message)
+        } catch {
+            return errorText(error.localizedDescription)
+        }
+    }
+
+    // MARK: - sync_status
+
+    private static func handleSyncStatus(args: [String: Value]) throws -> CallTool.Result {
+        guard let outputStr = args["output"]?.stringValue else {
+            return errorText("Missing required argument 'output'.")
+        }
+
+        let outputURL = URL(fileURLWithPath: (outputStr as NSString).expandingTildeInPath).standardizedFileURL
+        let manifestURL = outputURL.appendingPathComponent(SyncManifest.filename)
+
+        guard let manifest = SyncManifest.load(from: outputURL) else {
+            struct Response: Encodable {
+                let manifestFound: Bool
+                let outputDirectory: String
+                let manifestPath: String
+            }
+            return jsonText(Response(manifestFound: false,
+                                     outputDirectory: outputURL.path,
+                                     manifestPath: manifestURL.path))
+        }
+
+        struct Response: Encodable {
+            let manifestFound: Bool
+            let lastSync: Date
+            let trackedNotes: Int
+            let manifestPath: String
+        }
+        return jsonText(Response(manifestFound: true,
+                                 lastSync: manifest.lastSync,
+                                 trackedNotes: manifest.notes.count,
+                                 manifestPath: manifestURL.path))
+    }
+
+    // MARK: - Helpers
+
+    private static func jsonText<T: Encodable>(_ value: T) -> CallTool.Result {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = (try? encoder.encode(value)) ?? Data("{}" .utf8)
+        return CallTool.Result(
+            content: [.text(String(data: data, encoding: .utf8) ?? "{}")],
+            isError: false
+        )
+    }
+
+    private static func errorText(_ message: String) -> CallTool.Result {
+        CallTool.Result(content: [.text(message)], isError: true)
+    }
+
+    private static func parseDate(_ string: String) -> Date? {
+        let isoFull = ISO8601DateFormatter()
+        isoFull.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFull.date(from: string) { return date }
+
+        let isoBasic = ISO8601DateFormatter()
+        if let date = isoBasic.date(from: string) { return date }
+
+        let dateOnly = DateFormatter()
+        dateOnly.dateFormat = "yyyy-MM-dd"
+        dateOnly.timeZone = TimeZone(identifier: "UTC")
+        return dateOnly.date(from: string)
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter MCP/NotesMCPServer.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter MCP/NotesMCPServer.swift
@@ -1,0 +1,49 @@
+//
+//  NotesMCPServer.swift
+//  Apple Notes Exporter MCP
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import MCP
+
+// MARK: - MCP Server Entry Point
+
+@main
+struct NotesMCPServer {
+    static func main() async throws {
+        let server = Server(
+            name: "apple-notes-exporter",
+            version: "1.1.0",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+
+        // Register tool list handler
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: MCPToolHandlers.allTools)
+        }
+
+        // Register tool call handler — all routing is in MCPToolHandlers
+        await server.withMethodHandler(CallTool.self) { params in
+            await MCPToolHandlers.dispatch(params: params)
+        }
+
+        let transport = StdioTransport()
+        try await server.start(transport: transport)
+        await server.waitUntilCompleted()
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/project.pbxproj
+++ b/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		2519EE892E3BD57E00CC5D3C /* FullDiskAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 2519EE882E3BD57E00CC5D3C /* FullDiskAccess */; };
 		2519EE8B2E3BDE5E00CC5D3C /* HtmlToPdf in Frameworks */ = {isa = PBXBuildFile; productRef = 2519EE8A2E3BDE5E00CC5D3C /* HtmlToPdf */; };
 		257242462BF18F7700BD9A67 /* utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257242452BF18F7700BD9A67 /* utilities.swift */; };
+		EE000000000000000100SUPP /* ExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000000000XSUPP /* ExportSupport.swift */; };
+		EE000000000000000101SUPP /* ExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000000000XSUPP /* ExportSupport.swift */; };
+		EE000000000000000102SUPP /* ExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000000000XSUPP /* ExportSupport.swift */; };
 		257E911F2BF26FC10052606E /* ExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257E911E2BF26FC10052606E /* ExportView.swift */; };
 		257E91212BF26FD30052606E /* NoteSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257E91202BF26FD30052606E /* NoteSelectorView.swift */; };
 		258D3A9329A7CC2E00858CE1 /* AppleNotesExporterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258D3A9229A7CC2E00858CE1 /* AppleNotesExporterApp.swift */; };
@@ -35,10 +38,54 @@
 		A8F32496C70C760F63A553A8 /* ExportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF86799EAEEA063229FD0106 /* ExportViewModel.swift */; };
 		AAAA000000000002LICENSES /* Licenses in Resources */ = {isa = PBXBuildFile; fileRef = AAAA000000000001LICENSES /* Licenses */; };
 		B2D4E9A1F3C8A7B5D6E0F123 /* SyncManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3F7B2E4C9D8A6F5B0E234 /* SyncManifest.swift */; };
+		BB000000000000000001MAIN /* NotesExportCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000001MAIN /* NotesExportCLI.swift */; };
+		BB000000000000000002ENGN /* CLIExportEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000002ENGN /* CLIExportEngine.swift */; };
+		BB000000000000000003OUTP /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000003OUTP /* CLIOutput.swift */; };
+		BB000000000000000004ERRO /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000004ERRO /* CLIError.swift */; };
+		BB000000000000000005LACC /* ListAccountsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000005LACC /* ListAccountsCommand.swift */; };
+		BB000000000000000006LFLD /* ListFoldersCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000006LFLD /* ListFoldersCommand.swift */; };
+		BB000000000000000007LNOT /* ListNotesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000007LNOT /* ListNotesCommand.swift */; };
+		BB000000000000000008EXPC /* ExportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000008EXPC /* ExportCommand.swift */; };
+		BB000000000000000009KITC /* AppleNotesKit.c in Sources */ = {isa = PBXBuildFile; fileRef = 2508168E2F527B6400CD5778 /* AppleNotesKit.c */; };
+		BB000000000000000009SYNC /* SyncStatusCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000009SYNC /* SyncStatusCommand.swift */; };
+		BB00000000000000000AMODS /* NotesModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213C2B20532A819D34D10996 /* NotesModels.swift */; };
+		BB00000000000000000BREPO /* NotesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D188009F1E92C1561588B /* NotesRepository.swift */; };
+		BB00000000000000000CCFGR /* ExportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83A62FC148D1934031FD191 /* ExportConfiguration.swift */; };
+		BB00000000000000000DSYNC /* SyncManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3F7B2E4C9D8A6F5B0E234 /* SyncManifest.swift */; };
+		BB00000000000000000EHTMG /* NoteHTMLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000001HTMLGEN /* NoteHTMLGenerator.swift */; };
+		BB00000000000000000FDATC /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC000000000001DATCMP /* Data+Compression.swift */; };
+		BB00000000000000000GPBSW /* notestore.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A01F0A2E8F3EEF00C7D9FA /* notestore.pb.swift */; };
+		BB00000000000000000HHTML /* HTMLAttachmentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E296FC967ECC48BECE58F68 /* HTMLAttachmentProcessor.swift */; };
+		BB00000000000000000ITABL /* TableParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A703BDEDC79C3484E6F80575 /* TableParser.swift */; };
+		BB00000000000000000JNOTE /* NotesNote+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE68A68DD8DB569C0E58F0F /* NotesNote+Export.swift */; };
+		BB00000000000000000KSQLT /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 250816952F527BBB00CD5778 /* libsqlite3.tbd */; };
+		BB00000000000000000LZLIB /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 25A01F112E8F3FBE00C7D9FA /* libz.tbd */; };
+		BB00000000000000000MSPRT /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = II000000000000000002SPDP /* SwiftProtobuf */; };
+		BB00000000000000000NAPAR /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = II000000000000000001APDP /* ArgumentParser */; };
+		BB00000000000000002MSVR /* NotesMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000002MSVR /* NotesMCPServer.swift */; };
+		BB00000000000000003MHND /* MCPToolHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000003MHND /* MCPToolHandlers.swift */; };
 		BBBB000000000002HTMLGEN /* NoteHTMLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000001HTMLGEN /* NoteHTMLGenerator.swift */; };
 		CCCC000000000002DATCMP /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC000000000001DATCMP /* Data+Compression.swift */; };
 		CD247032451BCF2264B446AC /* FormatOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F873000AF0346FE18B1971CF /* FormatOptionsView.swift */; };
 		F6A42B2B6E8AFF8161AA22CE /* HTMLAttachmentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E296FC967ECC48BECE58F68 /* HTMLAttachmentProcessor.swift */; };
+		MC000000000000000001KITC /* AppleNotesKit.c in Sources */ = {isa = PBXBuildFile; fileRef = 2508168E2F527B6400CD5778 /* AppleNotesKit.c */; };
+		MC000000000000000002MODS /* NotesModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213C2B20532A819D34D10996 /* NotesModels.swift */; };
+		MC000000000000000003REPO /* NotesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112D188009F1E92C1561588B /* NotesRepository.swift */; };
+		MC000000000000000004CFGR /* ExportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83A62FC148D1934031FD191 /* ExportConfiguration.swift */; };
+		MC000000000000000005SYNC /* SyncManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3F7B2E4C9D8A6F5B0E234 /* SyncManifest.swift */; };
+		MC000000000000000006HTMG /* NoteHTMLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000001HTMLGEN /* NoteHTMLGenerator.swift */; };
+		MC000000000000000007DATC /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC000000000001DATCMP /* Data+Compression.swift */; };
+		MC000000000000000008PBSW /* notestore.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A01F0A2E8F3EEF00C7D9FA /* notestore.pb.swift */; };
+		MC000000000000000009HTML /* HTMLAttachmentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E296FC967ECC48BECE58F68 /* HTMLAttachmentProcessor.swift */; };
+		MC00000000000000000ATABL /* TableParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A703BDEDC79C3484E6F80575 /* TableParser.swift */; };
+		MC00000000000000000BNOTE /* NotesNote+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE68A68DD8DB569C0E58F0F /* NotesNote+Export.swift */; };
+		MC00000000000000000CENGN /* CLIExportEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000002ENGN /* CLIExportEngine.swift */; };
+		MC00000000000000000DOUTP /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000003OUTP /* CLIOutput.swift */; };
+		MC00000000000000000EERRO /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000004ERRO /* CLIError.swift */; };
+		MC00000000000000000FSQLT /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 250816952F527BBB00CD5778 /* libsqlite3.tbd */; };
+		MC00000000000000000GZLIB /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 25A01F112E8F3FBE00C7D9FA /* libz.tbd */; };
+		MC00000000000000000HSPRT /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = II000000000000000006SPDP /* SwiftProtobuf */; };
+		MC00000000000000000IMCPP /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = II000000000000000005APDP /* MCP */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -82,6 +129,7 @@
 		250816952F527BBB00CD5778 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		2519EE832E3AEA7200CC5D3C /* LicensePermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensePermissionsView.swift; sourceTree = "<group>"; };
 		257242452BF18F7700BD9A67 /* utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = utilities.swift; sourceTree = "<group>"; };
+		EE00000000000000000XSUPP /* ExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportSupport.swift; sourceTree = "<group>"; };
 		257E911E2BF26FC10052606E /* ExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportView.swift; sourceTree = "<group>"; };
 		257E91202BF26FD30052606E /* NoteSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSelectorView.swift; sourceTree = "<group>"; };
 		258D3A8F29A7CC2E00858CE1 /* Apple Notes Exporter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Apple Notes Exporter.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,6 +150,21 @@
 		4DE68A68DD8DB569C0E58F0F /* NotesNote+Export.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NotesNote+Export.swift"; path = "Models/NotesNote+Export.swift"; sourceTree = "<group>"; };
 		5E296FC967ECC48BECE58F68 /* HTMLAttachmentProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentProcessor.swift; sourceTree = "<group>"; };
 		A703BDEDC79C3484E6F80575 /* TableParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableParser.swift; sourceTree = "<group>"; };
+		AA000000000000000001MAIN /* NotesExportCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesExportCLI.swift; sourceTree = "<group>"; };
+		AA000000000000000002ENGN /* CLIExportEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExportEngine.swift; sourceTree = "<group>"; };
+		AA000000000000000003OUTP /* CLIOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOutput.swift; sourceTree = "<group>"; };
+		AA000000000000000004ERRO /* CLIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIError.swift; sourceTree = "<group>"; };
+		AA000000000000000005LACC /* ListAccountsCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAccountsCommand.swift; sourceTree = "<group>"; };
+		AA000000000000000006LFLD /* ListFoldersCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListFoldersCommand.swift; sourceTree = "<group>"; };
+		AA000000000000000007LNOT /* ListNotesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListNotesCommand.swift; sourceTree = "<group>"; };
+		AA000000000000000008EXPC /* ExportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportCommand.swift; sourceTree = "<group>"; };
+		AA000000000000000009ENTI /* AppleNotesExporterCLI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppleNotesExporterCLI.entitlements; sourceTree = "<group>"; };
+		AA000000000000000009SYNC /* SyncStatusCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusCommand.swift; sourceTree = "<group>"; };
+		AA00000000000000000APROD /* notes-export */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "notes-export"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA00000000000000001MPROD /* notes-export-mcp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "notes-export-mcp"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA00000000000000002MSVR /* NotesMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesMCPServer.swift; sourceTree = "<group>"; };
+		AA00000000000000003MHND /* MCPToolHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPToolHandlers.swift; sourceTree = "<group>"; };
+		AA00000000000000004MENT /* AppleNotesExporterMCP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppleNotesExporterMCP.entitlements; sourceTree = "<group>"; };
 		AAAA000000000001LICENSES /* Licenses */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Licenses; sourceTree = "<group>"; };
 		B5D09E1923B3E3C03B035AEB /* NotesViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotesViewModel.swift; path = ViewModels/NotesViewModel.swift; sourceTree = "<group>"; };
 		BBBB000000000001HTMLGEN /* NoteHTMLGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteHTMLGenerator.swift; sourceTree = "<group>"; };
@@ -139,6 +202,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CC000000000000000002FRMS /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB00000000000000000KSQLT /* libsqlite3.tbd in Frameworks */,
+				BB00000000000000000LZLIB /* libz.tbd in Frameworks */,
+				BB00000000000000000MSPRT /* SwiftProtobuf in Frameworks */,
+				BB00000000000000000NAPAR /* ArgumentParser in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC000000000000000004FRMS /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				MC00000000000000000FSQLT /* libsqlite3.tbd in Frameworks */,
+				MC00000000000000000GZLIB /* libz.tbd in Frameworks */,
+				MC00000000000000000HSPRT /* SwiftProtobuf in Frameworks */,
+				MC00000000000000000IMCPP /* MCP in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -165,6 +250,8 @@
 			isa = PBXGroup;
 			children = (
 				258D3A9129A7CC2E00858CE1 /* Apple Notes Exporter */,
+				DD000000000000000001CGRP /* Apple Notes Exporter CLI */,
+				DD000000000000000003MCPG /* Apple Notes Exporter MCP */,
 				258D3AA329A7CC2F00858CE1 /* Apple Notes ExporterTests */,
 				258D3AAD29A7CC2F00858CE1 /* Apple Notes ExporterUITests */,
 				258D3A9029A7CC2E00858CE1 /* Products */,
@@ -178,6 +265,8 @@
 				258D3A8F29A7CC2E00858CE1 /* Apple Notes Exporter.app */,
 				258D3AA029A7CC2F00858CE1 /* Apple Notes ExporterTests.xctest */,
 				258D3AAA29A7CC2F00858CE1 /* Apple Notes ExporterUITests.xctest */,
+				AA00000000000000000APROD /* notes-export */,
+				AA00000000000000001MPROD /* notes-export-mcp */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -196,6 +285,7 @@
 				258D3A9829A7CC2F00858CE1 /* Preview Content */,
 				AAAA000000000001LICENSES /* Licenses */,
 				257242452BF18F7700BD9A67 /* utilities.swift */,
+				EE00000000000000000XSUPP /* ExportSupport.swift */,
 				257E911E2BF26FC10052606E /* ExportView.swift */,
 				257E91202BF26FD30052606E /* NoteSelectorView.swift */,
 				2519EE832E3AEA7200CC5D3C /* LicensePermissionsView.swift */,
@@ -273,6 +363,41 @@
 			name = Models;
 			sourceTree = "<group>";
 		};
+		DD000000000000000001CGRP /* Apple Notes Exporter CLI */ = {
+			isa = PBXGroup;
+			children = (
+				AA000000000000000001MAIN /* NotesExportCLI.swift */,
+				AA000000000000000002ENGN /* CLIExportEngine.swift */,
+				AA000000000000000003OUTP /* CLIOutput.swift */,
+				AA000000000000000004ERRO /* CLIError.swift */,
+				AA000000000000000009ENTI /* AppleNotesExporterCLI.entitlements */,
+				DD000000000000000002CMDS /* Commands */,
+			);
+			path = "Apple Notes Exporter CLI";
+			sourceTree = "<group>";
+		};
+		DD000000000000000002CMDS /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				AA000000000000000005LACC /* ListAccountsCommand.swift */,
+				AA000000000000000006LFLD /* ListFoldersCommand.swift */,
+				AA000000000000000007LNOT /* ListNotesCommand.swift */,
+				AA000000000000000008EXPC /* ExportCommand.swift */,
+				AA000000000000000009SYNC /* SyncStatusCommand.swift */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
+		DD000000000000000003MCPG /* Apple Notes Exporter MCP */ = {
+			isa = PBXGroup;
+			children = (
+				AA00000000000000002MSVR /* NotesMCPServer.swift */,
+				AA00000000000000003MHND /* MCPToolHandlers.swift */,
+				AA00000000000000004MENT /* AppleNotesExporterMCP.entitlements */,
+			);
+			path = "Apple Notes Exporter MCP";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -335,6 +460,46 @@
 			productReference = 258D3AAA29A7CC2F00858CE1 /* Apple Notes ExporterUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		EE000000000000000001TGTT /* notes-export */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = GG000000000000000001CFGL /* Build configuration list for PBXNativeTarget "notes-export" */;
+			buildPhases = (
+				CC000000000000000001SRCS /* Sources */,
+				CC000000000000000002FRMS /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "notes-export";
+			packageProductDependencies = (
+				II000000000000000001APDP /* ArgumentParser */,
+				II000000000000000002SPDP /* SwiftProtobuf */,
+			);
+			productName = "notes-export";
+			productReference = AA00000000000000000APROD /* notes-export */;
+			productType = "com.apple.product-type.tool";
+		};
+		EE000000000000000002TGTT /* notes-export-mcp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = GG000000000000000002CFGL /* Build configuration list for PBXNativeTarget "notes-export-mcp" */;
+			buildPhases = (
+				CC000000000000000003SRCS /* Sources */,
+				CC000000000000000004FRMS /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "notes-export-mcp";
+			packageProductDependencies = (
+				II000000000000000005APDP /* MCP */,
+				II000000000000000006SPDP /* SwiftProtobuf */,
+			);
+			productName = "notes-export-mcp";
+			productReference = AA00000000000000001MPROD /* notes-export-mcp */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -343,7 +508,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1640;
+				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					258D3A8E29A7CC2E00858CE1 = {
 						CreatedOnToolsVersion = 14.2;
@@ -355,6 +520,12 @@
 					258D3AA929A7CC2F00858CE1 = {
 						CreatedOnToolsVersion = 14.2;
 						TestTargetID = 258D3A8E29A7CC2E00858CE1;
+					};
+					EE000000000000000001TGTT = {
+						CreatedOnToolsVersion = 14.2;
+					};
+					EE000000000000000002TGTT = {
+						CreatedOnToolsVersion = 14.2;
 					};
 				};
 			};
@@ -371,6 +542,8 @@
 				25479E582E1C5D08003E49E6 /* XCRemoteSwiftPackageReference "swift-html-to-pdf" */,
 				2519EE872E3BD57E00CC5D3C /* XCRemoteSwiftPackageReference "FullDiskAccess" */,
 				25A01F0E2E8F3F6600C7D9FA /* XCRemoteSwiftPackageReference "swift-protobuf" */,
+				HH000000000000000001ARGP /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+				HH000000000000000002SDKP /* XCRemoteSwiftPackageReference "swift-sdk" */,
 			);
 			productRefGroup = 258D3A9029A7CC2E00858CE1 /* Products */;
 			projectDirPath = "";
@@ -379,6 +552,8 @@
 				258D3A8E29A7CC2E00858CE1 /* Apple Notes Exporter */,
 				258D3A9F29A7CC2F00858CE1 /* Apple Notes ExporterTests */,
 				258D3AA929A7CC2F00858CE1 /* Apple Notes ExporterUITests */,
+				EE000000000000000001TGTT /* notes-export */,
+				EE000000000000000002TGTT /* notes-export-mcp */,
 			);
 		};
 /* End PBXProject section */
@@ -416,6 +591,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				257242462BF18F7700BD9A67 /* utilities.swift in Sources */,
+				EE000000000000000100SUPP /* ExportSupport.swift in Sources */,
 				258D3A9529A7CC2E00858CE1 /* AppleNotesExporterView.swift in Sources */,
 				257E91212BF26FD30052606E /* NoteSelectorView.swift in Sources */,
 				25A01F0C2E8F3EEF00C7D9FA /* notestore.pb.swift in Sources */,
@@ -453,6 +629,58 @@
 			files = (
 				258D3AB129A7CC2F00858CE1 /* Apple_Notes_ExporterUITestsLaunchTests.swift in Sources */,
 				258D3AAF29A7CC2F00858CE1 /* Apple_Notes_ExporterUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC000000000000000001SRCS /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB000000000000000001MAIN /* NotesExportCLI.swift in Sources */,
+				BB000000000000000002ENGN /* CLIExportEngine.swift in Sources */,
+				BB000000000000000003OUTP /* CLIOutput.swift in Sources */,
+				BB000000000000000004ERRO /* CLIError.swift in Sources */,
+				BB000000000000000005LACC /* ListAccountsCommand.swift in Sources */,
+				BB000000000000000006LFLD /* ListFoldersCommand.swift in Sources */,
+				BB000000000000000007LNOT /* ListNotesCommand.swift in Sources */,
+				BB000000000000000008EXPC /* ExportCommand.swift in Sources */,
+				BB000000000000000009SYNC /* SyncStatusCommand.swift in Sources */,
+				BB000000000000000009KITC /* AppleNotesKit.c in Sources */,
+				BB00000000000000000AMODS /* NotesModels.swift in Sources */,
+				BB00000000000000000BREPO /* NotesRepository.swift in Sources */,
+				BB00000000000000000CCFGR /* ExportConfiguration.swift in Sources */,
+				BB00000000000000000DSYNC /* SyncManifest.swift in Sources */,
+				EE000000000000000101SUPP /* ExportSupport.swift in Sources */,
+				BB00000000000000000EHTMG /* NoteHTMLGenerator.swift in Sources */,
+				BB00000000000000000FDATC /* Data+Compression.swift in Sources */,
+				BB00000000000000000GPBSW /* notestore.pb.swift in Sources */,
+				BB00000000000000000HHTML /* HTMLAttachmentProcessor.swift in Sources */,
+				BB00000000000000000ITABL /* TableParser.swift in Sources */,
+				BB00000000000000000JNOTE /* NotesNote+Export.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC000000000000000003SRCS /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB00000000000000002MSVR /* NotesMCPServer.swift in Sources */,
+				BB00000000000000003MHND /* MCPToolHandlers.swift in Sources */,
+				MC000000000000000001KITC /* AppleNotesKit.c in Sources */,
+				MC000000000000000002MODS /* NotesModels.swift in Sources */,
+				MC000000000000000003REPO /* NotesRepository.swift in Sources */,
+				MC000000000000000004CFGR /* ExportConfiguration.swift in Sources */,
+				MC000000000000000005SYNC /* SyncManifest.swift in Sources */,
+				EE000000000000000102SUPP /* ExportSupport.swift in Sources */,
+				MC000000000000000006HTMG /* NoteHTMLGenerator.swift in Sources */,
+				MC000000000000000007DATC /* Data+Compression.swift in Sources */,
+				MC000000000000000008PBSW /* notestore.pb.swift in Sources */,
+				MC000000000000000009HTML /* HTMLAttachmentProcessor.swift in Sources */,
+				MC00000000000000000ATABL /* TableParser.swift in Sources */,
+				MC00000000000000000BNOTE /* NotesNote+Export.swift in Sources */,
+				MC00000000000000000CENGN /* CLIExportEngine.swift in Sources */,
+				MC00000000000000000DOUTP /* CLIOutput.swift in Sources */,
+				MC00000000000000000EERRO /* CLIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -529,6 +757,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -584,6 +813,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -603,7 +833,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Apple Notes Exporter/Preview Content\"";
-				DEVELOPMENT_TEAM = Q7TB7B38LW;
+				DEVELOPMENT_TEAM = T4J2388378;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -636,14 +866,12 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Apple Notes Exporter/Apple_Notes_Exporter.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Apple Notes Exporter/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = Q7TB7B38LW;
+				DEVELOPMENT_TEAM = T4J2388378;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -675,6 +903,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
@@ -693,6 +922,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
@@ -710,6 +940,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.zaremski.Apple-Notes-ExporterUITests";
@@ -726,6 +957,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.zaremski.Apple-Notes-ExporterUITests";
@@ -733,6 +965,102 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = "Apple Notes Exporter";
+			};
+			name = Release;
+		};
+		FF000000000000000001DBUG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Apple Notes Exporter CLI/AppleNotesExporterCLI.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/**";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.1;
+				OTHER_SWIFT_FLAGS = "-DCLI_TARGET";
+				PRODUCT_BUNDLE_IDENTIFIER = com.zaremski.AppleNotesExporterCLI;
+				PRODUCT_NAME = "notes-export";
+				SWIFT_OBJC_BRIDGING_HEADER = "Apple Notes Exporter/AppleNotesKit/AppleNotesKit-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FF000000000000000002RLSE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Apple Notes Exporter CLI/AppleNotesExporterCLI.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/**";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.1;
+				OTHER_SWIFT_FLAGS = "-DCLI_TARGET";
+				PRODUCT_BUNDLE_IDENTIFIER = com.zaremski.AppleNotesExporterCLI;
+				PRODUCT_NAME = "notes-export";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_BRIDGING_HEADER = "Apple Notes Exporter/AppleNotesKit/AppleNotesKit-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		FF000000000000000003DBUG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Apple Notes Exporter MCP/AppleNotesExporterMCP.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/**";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.1;
+				OTHER_SWIFT_FLAGS = "-DCLI_TARGET";
+				PRODUCT_BUNDLE_IDENTIFIER = com.zaremski.AppleNotesExporterMCP;
+				PRODUCT_NAME = "notes-export-mcp";
+				SWIFT_OBJC_BRIDGING_HEADER = "Apple Notes Exporter/AppleNotesKit/AppleNotesKit-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FF000000000000000004RLSE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Apple Notes Exporter MCP/AppleNotesExporterMCP.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T4J2388378;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/**";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.1;
+				OTHER_SWIFT_FLAGS = "-DCLI_TARGET";
+				PRODUCT_BUNDLE_IDENTIFIER = com.zaremski.AppleNotesExporterMCP;
+				PRODUCT_NAME = "notes-export-mcp";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_BRIDGING_HEADER = "Apple Notes Exporter/AppleNotesKit/AppleNotesKit-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -775,6 +1103,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		GG000000000000000001CFGL /* Build configuration list for PBXNativeTarget "notes-export" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FF000000000000000001DBUG /* Debug */,
+				FF000000000000000002RLSE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		GG000000000000000002CFGL /* Build configuration list for PBXNativeTarget "notes-export-mcp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FF000000000000000003DBUG /* Debug */,
+				FF000000000000000004RLSE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -802,6 +1148,22 @@
 				minimumVersion = 1.31.1;
 			};
 		};
+		HH000000000000000001ARGP /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+		HH000000000000000002SDKP /* XCRemoteSwiftPackageReference "swift-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/modelcontextprotocol/swift-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -816,6 +1178,26 @@
 			productName = HtmlToPdf;
 		};
 		25A01F0F2E8F3F6600C7D9FA /* SwiftProtobuf */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 25A01F0E2E8F3F6600C7D9FA /* XCRemoteSwiftPackageReference "swift-protobuf" */;
+			productName = SwiftProtobuf;
+		};
+		II000000000000000001APDP /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = HH000000000000000001ARGP /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+		II000000000000000002SPDP /* SwiftProtobuf */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 25A01F0E2E8F3F6600C7D9FA /* XCRemoteSwiftPackageReference "swift-protobuf" */;
+			productName = SwiftProtobuf;
+		};
+		II000000000000000005APDP /* MCP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = HH000000000000000002SDKP /* XCRemoteSwiftPackageReference "swift-sdk" */;
+			productName = MCP;
+		};
+		II000000000000000006SPDP /* SwiftProtobuf */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 25A01F0E2E8F3F6600C7D9FA /* XCRemoteSwiftPackageReference "swift-protobuf" */;
 			productName = SwiftProtobuf;

--- a/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b0bd8185bd7b73046ca5f75dc82593433495120c344275f5f2e7c15a6809f826",
+  "originHash" : "4d8b37621dc4e4e7705f9072fe2c62af59da7db36eccffcd53912c004e621af2",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -20,12 +29,48 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
         "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
         "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
+        "version" : "1.4.0"
       }
     },
     {
@@ -51,8 +96,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/coenttb/swift-html-to-pdf",
       "state" : {
-        "revision" : "445d920c28b4b62d3208763511794253fd7c9e15",
+        "revision" : "2bcb9059fba7ab223d0aaa2211e8bfe4c7909446",
         "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version" : "2.95.0"
       }
     },
     {
@@ -65,12 +128,30 @@
       }
     },
     {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk",
+      "state" : {
+        "revision" : "6112a3995a992d159ad0e82c2d62a008ce932666",
+        "version" : "0.11.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {

--- a/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/xcshareddata/xcschemes/notes-export-mcp.xcscheme
+++ b/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/xcshareddata/xcschemes/notes-export-mcp.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,9 +15,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-               BuildableName = "Apple Notes Exporter.app"
-               BlueprintName = "Apple Notes Exporter"
+               BlueprintIdentifier = "EE000000000000000002TGTT"
+               BuildableName = "notes-export-mcp"
+               BlueprintName = "notes-export-mcp"
                ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,33 +29,9 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3A9F29A7CC2F00858CE1"
-               BuildableName = "Apple Notes ExporterTests.xctest"
-               BlueprintName = "Apple Notes ExporterTests"
-               ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3AA929A7CC2F00858CE1"
-               BuildableName = "Apple Notes ExporterUITests.xctest"
-               BlueprintName = "Apple Notes ExporterUITests"
-               ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -62,14 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-            BuildableName = "Apple Notes Exporter.app"
-            BlueprintName = "Apple Notes Exporter"
+            BlueprintIdentifier = "EE000000000000000002TGTT"
+            BuildableName = "notes-export-mcp"
+            BlueprintName = "notes-export-mcp"
             ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -84,9 +62,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-            BuildableName = "Apple Notes Exporter.app"
-            BlueprintName = "Apple Notes Exporter"
+            BlueprintIdentifier = "EE000000000000000002TGTT"
+            BuildableName = "notes-export-mcp"
+            BlueprintName = "notes-export-mcp"
             ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/xcshareddata/xcschemes/notes-export.xcscheme
+++ b/Apple Notes Exporter/Apple Notes Exporter.xcodeproj/xcshareddata/xcschemes/notes-export.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,9 +15,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-               BuildableName = "Apple Notes Exporter.app"
-               BlueprintName = "Apple Notes Exporter"
+               BlueprintIdentifier = "EE000000000000000001TGTT"
+               BuildableName = "notes-export"
+               BlueprintName = "notes-export"
                ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,33 +29,9 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3A9F29A7CC2F00858CE1"
-               BuildableName = "Apple Notes ExporterTests.xctest"
-               BlueprintName = "Apple Notes ExporterTests"
-               ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "258D3AA929A7CC2F00858CE1"
-               BuildableName = "Apple Notes ExporterUITests.xctest"
-               BlueprintName = "Apple Notes ExporterUITests"
-               ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -62,14 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-            BuildableName = "Apple Notes Exporter.app"
-            BlueprintName = "Apple Notes Exporter"
+            BlueprintIdentifier = "EE000000000000000001TGTT"
+            BuildableName = "notes-export"
+            BlueprintName = "notes-export"
             ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -84,9 +62,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "258D3A8E29A7CC2E00858CE1"
-            BuildableName = "Apple Notes Exporter.app"
-            BlueprintName = "Apple Notes Exporter"
+            BlueprintIdentifier = "EE000000000000000001TGTT"
+            BuildableName = "notes-export"
+            BlueprintName = "notes-export"
             ReferencedContainer = "container:Apple Notes Exporter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Apple Notes Exporter/Apple Notes Exporter/AppleNotesExporterApp.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/AppleNotesExporterApp.swift
@@ -42,15 +42,6 @@ let PAGE_US_LETTER: (width: Int, height: Int) = (612, 792)
 let PAGE_US_LEGAL: (width: Int, height: Int) = (612, 1008)
 let PAGE_US_TABLOID: (width: Int, height: Int) = (792, 1224)
 let PAGE_A4: (width: Int, height: Int) = (595, 842)
-// Logger
-extension Logger {
-    /// Using your bundle identifier is a great way to ensure a unique identifier.
-    private static var subsystem = Bundle.main.bundleIdentifier!
-
-    static let noteQuery = Logger(subsystem: subsystem, category: "notequery")
-    static let noteExport = Logger(subsystem: subsystem, category: "noteexport")
-}
-
 extension Scene {
     func windowResizabilityContentSize() -> some Scene {
         if #available(macOS 13.0, *) {

--- a/Apple Notes Exporter/Apple Notes Exporter/AppleNotesKit/AppleNotesKit.c
+++ b/Apple Notes Exporter/Apple Notes Exporter/AppleNotesKit/AppleNotesKit.c
@@ -449,7 +449,7 @@ static void _prepare_statements(ane_db *db)
         /* iOS 11: three-table join via Z_11NOTES */
         snprintf(sql, sizeof(sql),
             "SELECT  ZICCLOUDSYNCINGOBJECT.Z_PK, "
-            "ZICCLOUDSYNCINGOBJECT.%s AS TITLE, "
+            "%s AS TITLE, "
             "ZICCLOUDSYNCINGOBJECT.%s AS CREATION_DATE, "
             "ZICCLOUDSYNCINGOBJECT.%s AS MODIFICATION_DATE, "
             "Z_11NOTES.Z_11FOLDERS AS FOLDER_ID, "
@@ -468,7 +468,7 @@ static void _prepare_statements(ane_db *db)
     } else {
         /* iOS 12+: standard two-table join */
         snprintf(sql, sizeof(sql),
-            "SELECT  note.Z_PK, note.%s AS TITLE, "
+            "SELECT  note.Z_PK, %s AS TITLE, "
             "note.%s AS CREATION_DATE, "
             "note.%s AS MODIFICATION_DATE, "
             "note.%s AS FOLDER_ID, "
@@ -492,7 +492,7 @@ static void _prepare_statements(ane_db *db)
     /* STMT_NOTES_RANGE -- date-filtered variant (modern only, not iOS 11) */
     if (!is_ios11) {
         snprintf(sql, sizeof(sql),
-            "SELECT  note.Z_PK, note.%s AS TITLE, "
+            "SELECT  note.Z_PK, %s AS TITLE, "
             "note.%s AS CREATION_DATE, "
             "note.%s AS MODIFICATION_DATE, "
             "note.%s AS FOLDER_ID, "
@@ -821,8 +821,13 @@ static const char *_resolve_folder_account_col(const ane_db *db)
 
 static const char *_resolve_title_col(const ane_db *db)
 {
-    if (_has_column(db, "ZTITLE2"))    return "ZTITLE2";
-    if (_has_column(db, "ZTITLE1"))    return "ZTITLE1";
+    int has2 = _has_column(db, "ZTITLE2");
+    int has1 = _has_column(db, "ZTITLE1");
+    /* Use COALESCE so handwriting-recognized titles stored in ZTITLE1 are picked up
+     * even when the schema also has ZTITLE2 (which is NULL for handwritten notes). */
+    if (has2 && has1) return "COALESCE(ZTITLE2, ZTITLE1, ZTITLE)";
+    if (has2)         return "COALESCE(ZTITLE2, ZTITLE)";
+    if (has1)         return "COALESCE(ZTITLE1, ZTITLE)";
     return "ZTITLE";
 }
 

--- a/Apple Notes Exporter/Apple Notes Exporter/ExportSupport.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/ExportSupport.swift
@@ -1,0 +1,108 @@
+//
+//  ExportSupport.swift
+//  Apple Notes Exporter
+//
+//  Copyright (C) 2026 Konstantin Zaremski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import OSLog
+
+// MARK: - Logger Categories
+
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier ?? "com.zaremski.AppleNotesExporter"
+    static let noteQuery = Logger(subsystem: subsystem, category: "notequery")
+    static let noteExport = Logger(subsystem: subsystem, category: "noteexport")
+}
+
+// MARK: - Sync Manifest Actor
+
+/// Thread-safe wrapper for SyncManifest mutations during concurrent export
+actor SyncManifestTracker {
+    private var manifest: SyncManifest
+
+    init(manifest: SyncManifest) {
+        self.manifest = manifest
+    }
+
+    func recordExport(noteId: String, modificationDate: Date, exportedPath: String, attachmentPaths: [String] = []) {
+        manifest.recordExport(noteId: noteId, modificationDate: modificationDate, exportedPath: exportedPath, attachmentPaths: attachmentPaths)
+    }
+
+    func getManifest() -> SyncManifest {
+        return manifest
+    }
+}
+
+// MARK: - Export Progress Tracker Actor
+
+actor ExportProgressTracker {
+    private var completedCount: Int = 0
+    private var failedNotesCount: Int = 0
+    private var failedAttachmentsCount: Int = 0
+
+    func noteCompleted() -> Int {
+        completedCount += 1
+        return completedCount
+    }
+
+    func noteFailed() {
+        failedNotesCount += 1
+    }
+
+    func attachmentFailed() {
+        failedAttachmentsCount += 1
+    }
+
+    func getStats() -> (completed: Int, failedNotes: Int, failedAttachments: Int) {
+        return (completedCount, failedNotesCount, failedAttachmentsCount)
+    }
+}
+
+// MARK: - String Extensions for Escaping
+
+extension String {
+    var htmlEscaped: String {
+        self
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    var rtfEscaped: String {
+        self
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "{", with: "\\{")
+            .replacingOccurrences(of: "}", with: "\\}")
+    }
+
+    var texEscaped: String {
+        self
+            .replacingOccurrences(of: "\\", with: "\\textbackslash{}")
+            .replacingOccurrences(of: "&", with: "\\&")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "#", with: "\\#")
+            .replacingOccurrences(of: "_", with: "\\_")
+            .replacingOccurrences(of: "{", with: "\\{")
+            .replacingOccurrences(of: "}", with: "\\}")
+            .replacingOccurrences(of: "~", with: "\\textasciitilde{}")
+            .replacingOccurrences(of: "^", with: "\\textasciicircum{}")
+    }
+}

--- a/Apple Notes Exporter/Apple Notes Exporter/HTMLAttachmentProcessor.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/HTMLAttachmentProcessor.swift
@@ -21,7 +21,9 @@
 import Foundation
 import SQLite3
 import OSLog
+#if !CLI_TARGET
 import AppKit
+#endif
 
 /// Processes HTML to replace attachment placeholders with inline content or links
 class HTMLAttachmentProcessor {
@@ -451,6 +453,7 @@ class HTMLAttachmentProcessor {
             Logger.noteQuery.debug("Successfully retrieved \(size) bytes of image data from ZMEDIA for UUID \(uuid)")
 
             // Convert HEIC to JPEG to avoid WebKit rendering issues
+            #if !CLI_TARGET
             if typeUTI.contains("heic") || typeUTI.contains("HEIC") {
                 if let convertedData = convertHEICToJPEG(data) {
                     Logger.noteQuery.debug("Converted HEIC to JPEG for UUID \(uuid), new size: \(convertedData.count) bytes")
@@ -459,6 +462,7 @@ class HTMLAttachmentProcessor {
                     Logger.noteQuery.warning("Failed to convert HEIC to JPEG for UUID \(uuid), using original data")
                 }
             }
+            #endif
 
             return data.base64EncodedString()
         }
@@ -482,6 +486,7 @@ class HTMLAttachmentProcessor {
             Logger.noteQuery.debug("Successfully loaded \(data.count) bytes from external file for UUID \(uuid)")
 
             // Convert HEIC to JPEG to avoid WebKit rendering issues
+            #if !CLI_TARGET
             if typeUTI.contains("heic") || typeUTI.contains("HEIC") || fullPath.hasSuffix(".heic") || fullPath.hasSuffix(".HEIC") {
                 if let convertedData = convertHEICToJPEG(data) {
                     Logger.noteQuery.debug("Converted external HEIC to JPEG for UUID \(uuid), new size: \(convertedData.count) bytes")
@@ -490,6 +495,7 @@ class HTMLAttachmentProcessor {
                     Logger.noteQuery.warning("Failed to convert external HEIC to JPEG for UUID \(uuid), using original data")
                 }
             }
+            #endif
 
             return data.base64EncodedString()
         } catch {
@@ -498,6 +504,7 @@ class HTMLAttachmentProcessor {
         }
     }
 
+#if !CLI_TARGET
     /// Convert HEIC image data to JPEG to avoid WebKit rendering issues
     /// Returns nil if conversion fails
     private func convertHEICToJPEG(_ heicData: Data) -> Data? {
@@ -524,6 +531,7 @@ class HTMLAttachmentProcessor {
 
         return jpegData
     }
+#endif
 
     /// Convert UTI to MIME type
     private func utiToMimeType(_ uti: String) -> String {

--- a/Apple Notes Exporter/Apple Notes Exporter/Models/ExportConfiguration.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/Models/ExportConfiguration.swift
@@ -19,7 +19,9 @@
 //
 
 import Foundation
+#if !CLI_TARGET
 import HtmlToPdf
+#endif
 
 // MARK: - Base Configuration Protocol
 
@@ -65,6 +67,7 @@ struct HTMLConfiguration: ExportConfigurable {
         }
     }
 
+#if !CLI_TARGET
     /// Convert margin settings to PDF EdgeInsets (in points)
     func toPDFEdgeInsets() -> HtmlToPdf.EdgeInsets {
         // Convert margin to points based on unit
@@ -118,6 +121,7 @@ struct HTMLConfiguration: ExportConfigurable {
             right: marginInPoints
         )
     }
+#endif
 
     static var defaultConfiguration: HTMLConfiguration {
         HTMLConfiguration(
@@ -162,7 +166,7 @@ struct PDFConfiguration: ExportConfigurable {
 
     static var defaultConfiguration: PDFConfiguration {
         // Locale-aware default: Letter for US, A4 for rest of world
-        let defaultPageSize: PageSize = Locale.current.regionCode == "US" ? .letter : .a4
+        let defaultPageSize: PageSize = Locale.current.region?.identifier == "US" ? .letter : .a4
 
         return PDFConfiguration(
             htmlConfiguration: .defaultConfiguration,

--- a/Apple Notes Exporter/Apple Notes Exporter/Models/NotesModels.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/Models/NotesModels.swift
@@ -20,6 +20,14 @@
 
 import Foundation
 
+// MARK: - Sort Options
+
+enum NoteSortOption: String, CaseIterable {
+    case name = "Name"
+    case dateModified = "Date Modified"
+    case dateCreated = "Date Created"
+}
+
 // MARK: - Base Protocol
 
 /// Base protocol for all Notes items (accounts, folders, notes, attachments)

--- a/Apple Notes Exporter/Apple Notes Exporter/Repository/NotesRepository.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/Repository/NotesRepository.swift
@@ -198,7 +198,23 @@ class DatabaseNotesRepository: NotesRepository, @unchecked Sendable {
 
                 for i in 0..<count {
                     let n = raw[i]
-                    let title = n.title != nil ? String(cString: n.title) : "Untitled"
+
+                    // Title: COALESCE(ZTITLE2, ZTITLE1, ZTITLE) in the SQL covers typed and
+                    // handwriting-recognized notes; fall back to creation date for pure ink
+                    // drawings where all three title columns are NULL.
+                    let title: String
+                    if let ptr = n.title {
+                        let t = String(cString: ptr).trimmingCharacters(in: .whitespacesAndNewlines)
+                        if t.isEmpty {
+                            let df = DateFormatter(); df.dateFormat = "yyyy-MM-dd"
+                            title = df.string(from: Date(timeIntervalSinceReferenceDate: n.creation_date))
+                        } else {
+                            title = t
+                        }
+                    } else {
+                        let df = DateFormatter(); df.dateFormat = "yyyy-MM-dd"
+                        title = df.string(from: Date(timeIntervalSinceReferenceDate: n.creation_date))
+                    }
 
                     // Convert CoreTime dates to Swift Date
                     // CoreTime is seconds since 2001-01-01, Date(timeIntervalSinceReferenceDate:) uses the same epoch
@@ -407,6 +423,7 @@ class DatabaseNotesRepository: NotesRepository, @unchecked Sendable {
             foldersOnTop: foldersOnTop
         )
     }
+
 }
 
 // MARK: - Mock Implementation (for testing/previews)

--- a/Apple Notes Exporter/Apple Notes Exporter/ViewModels/ExportViewModel.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/ViewModels/ExportViewModel.swift
@@ -36,25 +36,6 @@ enum ExportError: Error, LocalizedError {
     }
 }
 
-// MARK: - Sync Manifest Actor
-
-/// Thread-safe wrapper for SyncManifest mutations during concurrent export
-actor SyncManifestTracker {
-    private var manifest: SyncManifest
-
-    init(manifest: SyncManifest) {
-        self.manifest = manifest
-    }
-
-    func recordExport(noteId: String, modificationDate: Date, exportedPath: String, attachmentPaths: [String] = []) {
-        manifest.recordExport(noteId: noteId, modificationDate: modificationDate, exportedPath: exportedPath, attachmentPaths: attachmentPaths)
-    }
-
-    func getManifest() -> SyncManifest {
-        return manifest
-    }
-}
-
 // MARK: - Export Progress
 
 struct ExportProgress: Equatable {
@@ -64,31 +45,6 @@ struct ExportProgress: Equatable {
     var percentage: Double {
         guard total > 0 else { return 0 }
         return Double(current) / Double(total)
-    }
-}
-
-// MARK: - Progress Tracker Actor
-
-actor ExportProgressTracker {
-    private var completedCount: Int = 0
-    private var failedNotesCount: Int = 0
-    private var failedAttachmentsCount: Int = 0
-
-    func noteCompleted() -> Int {
-        completedCount += 1
-        return completedCount
-    }
-
-    func noteFailed() {
-        failedNotesCount += 1
-    }
-
-    func attachmentFailed() {
-        failedAttachmentsCount += 1
-    }
-
-    func getStats() -> (completed: Int, failedNotes: Int, failedAttachments: Int) {
-        return (completedCount, failedNotesCount, failedAttachmentsCount)
     }
 }
 
@@ -1378,36 +1334,3 @@ class ExportViewModel: ObservableObject {
     }
 }
 
-// MARK: - String Extensions for Escaping
-
-extension String {
-    var htmlEscaped: String {
-        self
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
-    }
-
-    var rtfEscaped: String {
-        self
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "{", with: "\\{")
-            .replacingOccurrences(of: "}", with: "\\}")
-    }
-
-    var texEscaped: String {
-        self
-            .replacingOccurrences(of: "\\", with: "\\textbackslash{}")
-            .replacingOccurrences(of: "&", with: "\\&")
-            .replacingOccurrences(of: "%", with: "\\%")
-            .replacingOccurrences(of: "$", with: "\\$")
-            .replacingOccurrences(of: "#", with: "\\#")
-            .replacingOccurrences(of: "_", with: "\\_")
-            .replacingOccurrences(of: "{", with: "\\{")
-            .replacingOccurrences(of: "}", with: "\\}")
-            .replacingOccurrences(of: "~", with: "\\textasciitilde{}")
-            .replacingOccurrences(of: "^", with: "\\textasciicircum{}")
-    }
-}

--- a/Apple Notes Exporter/Apple Notes Exporter/ViewModels/NotesViewModel.swift
+++ b/Apple Notes Exporter/Apple Notes Exporter/ViewModels/NotesViewModel.swift
@@ -22,14 +22,6 @@ import Foundation
 import SwiftUI
 import OSLog
 
-// MARK: - Sort Options
-
-enum NoteSortOption: String, CaseIterable {
-    case name = "Name"
-    case dateModified = "Date Modified"
-    case dateCreated = "Date Created"
-}
-
 // MARK: - Notes ViewModel
 
 @MainActor


### PR DESCRIPTION
Hi! I appreciate the work you've put into this project. Apple Notes doesn't communicate well with other apps, so your exporter has become essential to my workflow.

To integrate it properly with Claude, I needed a command-line interface and a Model Context Protocol (MCP) server — so I built both on top of your existing codebase. I thought they might be useful to you and others, so I'm submitting them as a PR.

I'm also aware that AI-generated code isn't always welcome in open source projects — especially ones that are a learning experience or community effort. So please feel free to reject this if it doesn't fit your vision.

---

## What's added

- **`notes-export` CLI** — list and export notes from the terminal without opening the app. Subcommands: `list-accounts`, `list-folders`, `list-notes`, `export`. Outputs JSON; built with Swift ArgumentParser.
- **`notes-export-mcp` MCP server** — exposes 5 tools (`list_accounts`, `list_folders`, `list_notes`, `get_note`, `export_note`) so AI assistants like Claude Desktop can read and export notes directly.
- Both share your existing C parser (`AppleNotesKit`) and `NotesRepository` — no database logic was duplicated.

## Bug fix included

**Handwritten notes exported as "Untitled"** — on modern macOS the schema has both `ZTITLE2` and `ZTITLE1`. The parser was always reading `ZTITLE2`, but the handwriting-recognition title is stored in `ZTITLE1`. Fixed `_resolve_title_col()` to return `COALESCE(ZTITLE2, ZTITLE1, ZTITLE)` so the first non-NULL value wins. Pure ink drawings with no recognized text fall back to the creation date.

## Changes to existing files

| File | Change |
|------|--------|
| `ExportConfiguration.swift` | `#if !CLI_TARGET` guard around `import HtmlToPdf` and PDF methods |
| `HTMLAttachmentProcessor.swift` | `#if !CLI_TARGET` guard around `import AppKit` and HEIC conversion |
| `NotesModels.swift` | `NoteSortOption` moved here from `NotesViewModel.swift` for shared access |
| `ExportViewModel.swift` | `NoteSortOption` removed (now in `NotesModels.swift`) |
| `ExportSupport.swift` | New — Foundation-only shared types used by all three targets |
| `project.pbxproj` | CLI and MCP targets wired up; ArgumentParser SPM dependency added |
| `AppleNotesKit.c` | `_resolve_title_col()` uses COALESCE to fix handwritten note titles |
| `NotesRepository.swift` | Date fallback for pure ink notes where all title columns are NULL |

## Requirements

Both binaries require **Full Disk Access** at runtime (same as the GUI app) to read `NoteStore.sqlite`.

## Test plan
- [ ] Build `notes-export` → `notes-export list-accounts` returns JSON
- [ ] Build `notes-export-mcp` → server responds to MCP `initialize` + `tools/list`
- [ ] Build main app → no regressions
- [ ] Handwritten notes now export with their recognized title instead of "Untitled"